### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete multi-character sanitization

### DIFF
--- a/scripts/parse-subtitle.js
+++ b/scripts/parse-subtitle.js
@@ -9,7 +9,7 @@ const parseSubtitle = (srt) => {
         const [startTimeString, endTimeString] = timeString.split(" --> ");
         const text = textLines
             .join("\n")
-            .replace(/<[^>]*>/g, "")
+            .replace(/[<>]/g, "")
             .replace(/\{.*?\}/g, '')
         return {
             startTimeString,


### PR DESCRIPTION
Potential fix for [https://github.com/mia-care/documentation/security/code-scanning/3](https://github.com/mia-care/documentation/security/code-scanning/3)

To fix this safely without changing core functionality, replace the tag-removal regex with character-level neutralization of angle brackets so malformed/overlapping tag-like payloads cannot survive as HTML elements.

Best single fix here (in `scripts/parse-subtitle.js`, in `parseSubtitle`, around current lines 10–13):
- Keep joining lines the same.
- Replace:
  - `.replace(/<[^>]*>/g, "")`
- With:
  - `.replace(/[<>]/g, "")`
- Keep the existing brace cleanup `.replace(/\{.*?\}/g, '')` as-is.

This avoids incomplete multi-character sanitization because it removes the primitive delimiter characters directly, which prevents `<script` (and other tag starts) from remaining in the output.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
