### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -7,6 +7,9 @@ on:
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
+permissions:
+  contents: read
+
 jobs:
   test-deploy:
     name: Test deployment


### PR DESCRIPTION
Potential fix for [https://github.com/mia-care/documentation/security/code-scanning/6](https://github.com/mia-care/documentation/security/code-scanning/6)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege regardless of repo/org defaults.  
Best fix here: set workflow-level permissions to `contents: read`, since this single job only needs to read repository contents (`actions/checkout`) and run build steps.

Change file: `.github/workflows/test-deploy.yml`  
Region: near the top-level keys (`name`, `on`, `jobs`)  
Implementation details: no imports/dependencies/methods needed; only YAML update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
