### PR TITLE
fix: remove announcement banner from homepage

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -128,14 +128,6 @@ function Home() {
       description="The official handbook for Mia-Care P4SaMD — the Platform for Software as a Medical Device."
       title={siteConfig.title}
     >
-      {/* Announcement Banner */}
-      <div className={styles.announcementBanner}>
-        <span>🎉 P4SaMD v3 is now available — redesigned as a standalone platform.</span>
-        <Link className={styles.announcementLink} to="/docs/p4samd/release-notes/v3.0">
-          View release notes →
-        </Link>
-      </div>
-
       {/* Hero */}
       <header className={styles.hero}>
         <div className={clsx("container", styles.heroInner)}>

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -1,25 +1,5 @@
 /* stylelint-disable docusaurus/copyright-header */
 
-/* ─── Announcement banner ─────────────────────────────────────── */
-.announcementBanner {
-  background-color: var(--ifm-color-primary);
-  color: #fff;
-  text-align: center;
-  padding: 0.55rem 1rem;
-  font-size: 0.9rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.announcementLink {
-  color: #fff !important;
-  font-weight: 600;
-  text-decoration: underline;
-}
-
 /* ─── Hero ────────────────────────────────────────────────────── */
 .hero {
   padding: 5rem 0 4rem;


### PR DESCRIPTION
## Summary

Removes the announcement banner that appeared at the top of the P4SaMD handbook homepage at `docs.mia-care.io`.

The banner ("P4SaMD v3 is now available — redesigned as a standalone platform.") was introduced during the v3 documentation launch. It originates from a banner pattern inherited from the Mia-Platform documentation fork and is no longer appropriate: the v3 launch is now established, and this style of top-of-page announcement is not part of the intended handbook design.

## Changes

- `src/pages/index.js`: Removed the announcement banner `<div>` block from the `Home` component.
- `src/pages/styles.module.css`: Removed the `.announcementBanner` and `.announcementLink` CSS classes that were only used by the banner.

## Version Impact

- No new Docusaurus version created (homepage-only UI change, no documentation content affected).
- No release notes entry required (no user-facing feature change — this is a UI cleanup).

## Checklist

- [x] All content is written from the end-user perspective
- [x] No internal identifiers or private information included
- [x] Docusaurus build verified locally (or CI will verify)
- [x] Links and cross-references checked