### PR TITLE
docs: consolidate handbook to v3.x and document v3.1/v3.1.1/v3.2

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -2,15 +2,22 @@
   "version": "0.2",
   "language": "en",
   "words": [
+    "AES",
     "Fluentd",
+    "GCM",
+    "GCS",
     "GMLP",
     "IMDRF",
+    "Keycloak",
+    "LLM",
     "mitigations",
+    "OIDC",
     "rgba",
     "SDLC",
     "syft",
     "Traefik",
-    "Velero"
+    "Velero",
+    "Whisper"
   ],
   "ignoreWords": [],
   "dictionaries": [

--- a/docs/p4samd/handbook/ai_configuration.md
+++ b/docs/p4samd/handbook/ai_configuration.md
@@ -1,0 +1,53 @@
+---
+id: ai_configuration
+title: AI Configuration
+sidebar_label: AI Configuration
+---
+
+P4SaMD's AI capabilities — including the [Whisper AI Assistant](./whisper.md) and AI-powered compliance evaluation — are configured per organization by an administrator. This page explains how to enable AI features and connect your own LLM provider. AI configuration was introduced in **v3.2**.
+
+:::note Who can configure this
+Only users with the **Admin** role in the active organization can see and change AI configuration. See [Roles and Permissions](../security/roles_permissions.md).
+:::
+
+## Enabling AI Features
+
+AI capabilities are gated behind a per-organization **AI features** toggle in the organization settings. When AI features are off, the AI configuration forms are disabled and Whisper does not appear. Turning the toggle on makes the AI configuration available and surfaces Whisper to your team (once a chat provider is configured).
+
+## LLM Profiles
+
+P4SaMD uses your own LLM provider credentials, configured on the **LLM Profiles** settings page (under **Settings**). Credentials are assigned per **workload**, so you can use different providers or models for different purposes. There are two workloads:
+
+- **Chat** — powers the Whisper conversational assistant.
+- **Evaluation** — powers AI-based compliance analysis (the suggestions Whisper surfaces).
+
+Each workload is configured independently. This means you can, for example, use a fast, inexpensive model for chat and a more capable model for compliance evaluation.
+
+### Configuring a workload
+
+For each workload (Chat and Evaluation), provide:
+
+| Field | Description |
+|---|---|
+| **Provider** | The LLM provider. Supported options: **OpenAI**, **Anthropic**, **Google Vertex AI**, **Azure OpenAI**. |
+| **Model** | The default model used for the workload. |
+| **API Base URL** | The provider endpoint (when applicable). |
+| **API Key** | The credential used to authenticate with the provider. |
+
+Click **Save** to store the configuration. P4SaMD **validates the credentials live** before saving, so an invalid key is reported immediately ("Invalid API key. Please check your credentials and try again.") rather than failing later.
+
+Each workload shows its current status — **Configured** or **Not configured** — along with the date it was last updated. On the Chat workload, a **Use same configuration as Evaluation** action copies the Evaluation provider settings across, so you do not have to re-enter them.
+
+:::info Credential security
+API keys are stored **encrypted at rest (AES-256-GCM)** in the database. They are never returned to the browser; the configuration form only indicates whether a key is currently stored.
+:::
+
+### Available chat models
+
+A provider can optionally define an **allow-list of available models** in addition to its default model. When an allow-list is set, those models become selectable in the Whisper chat model picker; when it is empty, only the default model is available. You can also **discover** the live model list directly from the provider (OpenAI and Anthropic) to populate or refresh the available models.
+
+In chat, users may **override the model per message** by choosing from the available models. If a chosen model is unavailable or unrecognized, Whisper silently falls back to the default model. Evaluation always uses its single configured model.
+
+## How this powers Whisper
+
+Once **AI features** are enabled and a **Chat** profile is configured, the Whisper assistant becomes available to your team. The **Evaluation** profile drives the compliance suggestions Whisper displays for each version. If Whisper reports "No active chat provider configured", return here and assign a provider/model to the Chat workload.

--- a/docs/p4samd/handbook/getting_started.mdx
+++ b/docs/p4samd/handbook/getting_started.mdx
@@ -75,6 +75,10 @@ Once inside a project, the left sidebar gives you access to the full set of tool
 | **Documentation** | Generate compliance documentation and reports |
 | **AI Inventory** | Manage AI/ML components, model versions, and AI-specific compliance workflows (AI-Powered projects only) |
 
+<Tip>
+  Look for the **sparkles icon** in the top bar to open <strong>Whisper</strong>, the in-platform AI assistant. It surfaces compliance suggestions for the current version and answers questions in a chat. Whisper appears once an administrator enables AI features for your organization — see <a href="./ai_configuration">AI Configuration</a>.
+</Tip>
+
 </Step>
 
 <Step number={5} icon="🚀" title="Create or Import a Project">
@@ -103,5 +107,6 @@ See [Brownfield Import](./brownfield/overview) for the full walkthrough.
   { icon: '🏢', label: 'Organizations & multi-tenancy', to: './organizations' },
   { icon: '📦', label: 'Products & projects', to: './products' },
   { icon: '📝', label: 'Work with requirements', to: './requirements' },
+  { icon: '🤖', label: 'Whisper AI Assistant', to: './whisper' },
   { icon: '🔄', label: 'Brownfield Import', to: './brownfield/overview' },
 ]} />

--- a/docs/p4samd/handbook/organizations.mdx
+++ b/docs/p4samd/handbook/organizations.mdx
@@ -18,7 +18,9 @@ You can switch between organizations at any time without logging out. Click your
 
 ## Settings and Administration
 
-Organization administrators have access to a settings area where they can configure the organization's display name, default regulatory frameworks and compliance templates, feature toggles (such as enabling AI-powered capabilities), and connections to external tools such as git providers, CI/CD systems, or ALM platforms. These settings are scoped to the organization and do not affect other organizations on the same installation. Only users with the **Organization Admin** role can access this area.
+Organization administrators have access to a settings area where they can configure the organization's display name, default regulatory frameworks and compliance templates, feature toggles, and connections to external tools such as git providers, CI/CD systems, or ALM platforms. These settings are scoped to the organization and do not affect other organizations on the same installation. Only users with the **Admin** role can access this area.
+
+This includes enabling **AI features** for the organization and connecting your own LLM provider, which powers the [Whisper AI Assistant](./whisper.md) and AI-based compliance evaluation. See [AI Configuration](./ai_configuration.md) for the setup steps.
 
 ## Data Isolation
 

--- a/docs/p4samd/handbook/products.mdx
+++ b/docs/p4samd/handbook/products.mdx
@@ -22,9 +22,13 @@ Once you click **Create**, P4SaMD provisions the project and takes you directly 
 
 If you have an existing software system that you need to bring under a formal compliance process, use **Import Project** on the Products page to open the Brownfield Import wizard. The wizard guides you through six steps to describe the project, upload technical assets, and provide existing documentation. After submission, P4SaMD runs a compliance gap analysis and generates a prioritized remediation plan. See [Brownfield Import](./brownfield/overview) for the full walkthrough.
 
-## Managing Team Members
+## Managing Product Members
 
-Once inside a project, go to **Settings → Team Members** to add or remove users and adjust their roles. Roles control which sections of the project a user can view and which actions they can perform. See [Roles and Permissions](../security/roles_permissions) for a full description.
+Each project has a **Product Members** page (open it from **Members** in the project sidebar) where administrators control who has access and at what role. The page shows a member table with **search** and a **role filter**, plus a stats panel summarizing the team (Active, Admin, Tech Team, and Business users).
+
+Click **Add Member** to grant access: pick a user from your organization and assign a **Product Role** — **Admin**, **Tech Team**, **Business**, **QA**, or **Viewer**. The dialog includes a **Show capabilities** breakdown so you can see exactly what each role can do before assigning it. Removing a member is confirmed by typing their name and is blocked if it would leave the project without an Admin.
+
+At the organization level, the same page is shown as **Tenant Members** for managing organization-wide membership. See [Roles and Permissions](../security/roles_permissions.md) for the full role model.
 
 <NextSteps items={[
   { icon: '📝', label: 'Work with requirements', to: './requirements' },

--- a/docs/p4samd/handbook/whisper.md
+++ b/docs/p4samd/handbook/whisper.md
@@ -1,0 +1,77 @@
+---
+id: whisper
+title: Whisper AI Assistant
+sidebar_label: Whisper AI Assistant
+---
+
+**Whisper** is the in-platform AI assistant. It helps you keep a project compliant by continuously surfacing **compliance suggestions** for the active version and by answering questions and proposing changes through an interactive **chat**. Whisper is available from **v3.2**.
+
+:::info
+Whisper only appears when an administrator has enabled **AI features** for your organization and configured a chat provider. See [AI Configuration](./ai_configuration.md) to set this up.
+:::
+
+## Opening Whisper
+
+Whisper is available on every project-scoped page. Click the **sparkles icon** in the top navigation bar to open it. The assistant slides in as a panel on the right-hand side of the screen; you can **expand it to full page** and restore it to the panel at any time, and close it when you are done.
+
+A context strip at the top of the panel always shows the **project** and **version** Whisper is currently working against, so its suggestions and answers are scoped to the version you are reviewing.
+
+The sparkles icon carries a **badge** showing the number of open compliance findings for the active version, so you can see at a glance whether there is anything to address.
+
+## Compliance Suggestions
+
+In the **Suggestions** view, Whisper lists AI-detected compliance findings for the active version, sorted by priority (**High → Medium → Low**). Each finding is shown as a card with a title and a priority label.
+
+Clicking a finding opens a detail drawer containing:
+
+- **Priority** and **Category**
+- **Normative Reference** — the regulatory clause the finding relates to
+- **Description** and **Reasoning** — what was detected and why
+- **Remediation Steps** — suggested actions to resolve it
+- **Confidence** — how confident the analysis is in the finding
+
+### Running an analysis
+
+Click **Analyze now** to trigger a fresh compliance analysis of the active version. The list shows a re-analyzing indicator while the job runs and a confirmation once results are updated. A **freshness label** ("Updated N minutes ago") tells you how recently the analysis last ran, and the list also refreshes when you return to the tab.
+
+### Triaging findings
+
+Each finding can be handled directly from its card:
+
+- **Dismiss** — mark a finding as not applicable. You can add an optional reason.
+- **Resolve** — mark a finding as addressed.
+
+After you dismiss or resolve a finding, an **undo** prompt lets you reopen it. By default the list hides handled findings and the badge counts only **open** findings; use the **Show dismissed/resolved** toggle to see the full history.
+
+Findings automatically reconcile when your requirements change: unchanged findings are preserved, findings whose underlying item changed are reopened, and findings that no longer apply are superseded.
+
+## Chat
+
+Switch to **Chat** to ask Whisper questions in natural language. Answers stream in token by token, and conversations are saved so you can come back to them.
+
+- **Conversations** — a sidebar lists your past conversations; start a fresh one with **New chat**. Conversations are private to you within your organization.
+- **Composer** — type your question in the **Ask Whisper…** box and send it.
+- **References** — answers can cite the **normative references** they are based on, and every assistant message is clearly marked as **AI-generated**.
+
+### Confirmable actions
+
+Whisper can do more than answer questions — it can propose changes to your project (for example, creating or updating a requirement, or removing a risk link). When it does, it presents a **Proposed action** card with **Confirm** and **Decline** buttons.
+
+:::tip You are always in control
+Whisper never changes your data on its own. A proposed action is applied only when **you** confirm it. Confirmed and declined actions are attributed to you ("AI-assisted · confirmed by you") and recorded in the project audit log.
+:::
+
+### From a finding to a chat
+
+You can start a chat directly from a compliance finding to get help addressing it — Whisper opens a conversation seeded with the context of that finding, so it can suggest concrete remediation steps.
+
+### Choosing a model
+
+If your administrator has made more than one chat model available, you can pick which model answers a given message using the model selector in the chat. You can also refresh the list of available models from the configured provider. If a selected model is unavailable, Whisper falls back to the default model rather than failing.
+
+## When Whisper is unavailable
+
+Whisper reports a clear message when it cannot run, for example:
+
+- **AI features are disabled** — an administrator has not enabled AI for your organization.
+- **No active chat provider configured** — AI is enabled but no chat provider/model has been assigned. See [AI Configuration](./ai_configuration.md).

--- a/docs/p4samd/release-notes/v3.0.mdx
+++ b/docs/p4samd/release-notes/v3.0.mdx
@@ -122,6 +122,126 @@ New projects now start with a default workspace version named **main** (previous
 
 ---
 
+## P4SaMD v3.1
+
+**Release date**: 11 June 2026
+
+Version 3.1 deepens the native SDLC artifact management introduced in v3.0, with a focus on the **System Design** workspace, formal lifecycle controls, and team administration.
+
+### New: Software Item Lifecycle (System Design)
+
+Software items now carry a formal IEC 62304-aligned lifecycle status: **Draft → Approved → Verified**, plus a terminal **Deprecated** state. You move items through the lifecycle from the software item detail view:
+
+- **Approve** an item once its design is ready (requires the Admin role).
+- **Verify** an approved item once it has supporting evidence.
+- **Revert to Draft** to reopen an Approved or Verified item for further work.
+- **Deprecate** an item that is no longer in use. Deprecation is one-way, requires a written rationale (at least 10 characters), and is only available for items belonging to a released version.
+
+Items that belong to a **released** version are protected: they cannot be deleted, and editing them requires an edit rationale that is recorded in the item's history.
+
+### New: Tabbed Detail Pages for Requirements and Software Items
+
+Requirements and software items now open in a dedicated detail page with three tabs:
+
+- **Details** — view and inline-edit all fields, including the parent/child hierarchy and a system-metadata block (created/updated/approved by, with timestamps).
+- **Traceability** — see linked risks, tests, software items, and change requests, plus a risk-coverage indicator and a link to the traceability matrix.
+- **History** — a chronological audit trail of every create, edit, status transition, and deletion, now showing the human-readable name of the person who made each change.
+
+### New: Product Members Management
+
+Each project gets a **Members** page (shown as **Product Members** inside a project, **Tenant Members** at the organization level) for managing who has access and at what role. The page includes a member table with search and role filtering, a stats panel, and an **Add Member** dialog with an expandable per-role capability breakdown. Removing a member is guarded so you cannot remove the last Admin. See [Roles and Permissions](../security/roles_permissions.md) for the full role model.
+
+### Improved
+
+- Requirement and software item lists are now **sortable** and show a stats bar; requirements can be sorted by their display ID.
+- Label entry now offers **autocomplete suggestions** instead of a separate single-label filter.
+- Larger design files can be uploaded to software items without hitting a size limit.
+
+### Fixed
+
+- Switching organization now cancels in-flight requests and clears tenant-scoped cached data, so screens no longer briefly show data from the previously selected organization.
+- Corrected sort ordering on the Risk and Software Item lists.
+
+### For developers: extended MCP coverage
+
+The bundled MCP server gained broad new read/write coverage (requirement lifecycle transitions, full risk register management, traceability links, software item browsing, version management, and design-file access), so external AI assistants and coding agents can operate on project data without REST access.
+
+---
+
+## P4SaMD v3.1.1
+
+**Release date**: 12 June 2026
+
+A focused maintenance release that migrated file storage to a managed object store.
+
+### Changed: File storage migrated to Google Cloud Storage
+
+The self-hosted file storage backend was replaced with a managed **Google Cloud Storage (GCS)** bucket across all environments. This removes a single point of failure (an unreplicated storage pod) and the risk of data loss on restart, and simplifies credential management.
+
+:::warning Breaking change
+**Files uploaded before this release are not accessible afterward.** No data was migrated between the old storage and the new GCS bucket, so any previously uploaded files — for example design files in the System Design section — must be re-uploaded. This was an accepted trade-off given the platform's current internal-only audience and the small volume of stored data.
+:::
+
+---
+
+## P4SaMD v3.2
+
+**Expected: July 2026**
+
+Version 3.2 introduces **Whisper**, the in-platform AI assistant, together with the tenant-level **AI configuration** that powers it. This is the first release of the AI advisor capability previously on the roadmap.
+
+<FeatureGrid>
+
+<FeatureBox icon="🤖" title="Whisper AI Assistant">
+
+A new AI assistant available on every project page, opened from the sparkles icon in the top bar. Whisper surfaces **compliance suggestions** for the active version and offers an interactive **chat** that can read your project and propose changes for you to confirm.
+
+</FeatureBox>
+
+<FeatureBox icon="🔎" title="Compliance Suggestions">
+
+Whisper analyzes your active version and lists AI-detected compliance findings, sorted by priority, each with a normative reference, reasoning, remediation steps, and a confidence indicator. You can run a fresh analysis on demand and dismiss, resolve, or reopen each finding.
+
+</FeatureBox>
+
+<FeatureBox icon="💬" title="Conversational Chat with Confirmable Actions">
+
+Ask Whisper questions in natural language and get streamed answers. When the assistant proposes a change to your data (for example creating a requirement), it presents a **Confirm / Decline** card — nothing is changed without your explicit approval, and every confirmed or declined action is recorded in the audit log.
+
+</FeatureBox>
+
+<FeatureBox icon="⚙️" title="AI Configuration & LLM Profiles">
+
+Administrators can enable AI features per organization and assign an LLM provider and model to each workload — **Chat** and **Evaluation** — from a new **LLM Profiles** settings page, with live credential validation. Providers can expose an allow-list of selectable chat models, and the live model list can be discovered directly from the provider.
+
+</FeatureBox>
+
+</FeatureGrid>
+
+### New: Whisper AI Assistant
+
+The Whisper panel slides in from the right (and can be expanded to full page) and shows the current project and version context. Its two modes are:
+
+- **Compliance Suggestions** — AI-detected findings for the active version. The top-bar badge shows the count of open findings. Each finding opens a detail drawer (priority, category, normative reference, description, reasoning, remediation steps, confidence). **Analyze now** triggers a fresh analysis; findings can be **dismissed** or **resolved** (with an optional reason and an undo), and a freshness label shows how recently the analysis ran.
+- **Chat** — a conversational assistant with token-by-token streaming, persisted conversations you can resume or delete, and a per-message model picker. Proposed mutating actions require **Confirm / Decline**, and assistant messages are clearly marked as AI-generated.
+
+See the [Whisper AI Assistant](../handbook/whisper.md) handbook page for the full walkthrough.
+
+### New: AI Configuration
+
+A new **LLM Profiles** page under Settings (Admin-only) lets you configure AI provider credentials separately for the **Chat** and **Evaluation** workloads — so you can, for example, use one provider for chat and another for compliance evaluation. AI features are gated behind a per-organization **AI features** toggle. See [AI Configuration](../handbook/ai_configuration.md) for details.
+
+### For developers
+
+- The MCP tool catalog grew to **17 tools**, adding risk-management and software-item domain tools, now shared as a single source of truth with the Whisper agent.
+- AI assistant activity (confirmed/declined actions and conversation creation) is now written to the audit log.
+
+### Security
+
+- LLM provider API keys are now stored **encrypted at rest (AES-256-GCM)** in the database, removing the previous external secrets-manager dependency.
+
+---
+
 ## Product Roadmap
 
 P4SaMD v3 is an evolving platform. The features below are actively in development and will roll out in upcoming minor releases throughout 2026 and beyond:
@@ -164,9 +284,9 @@ Bill of Materials management for software components, dependencies, and SOUP ite
 
 </RoadmapItem>
 
-<RoadmapItem icon="🤖" title="Smart Insight AI Advisor" quarter="Q2 2027" status="planned">
+<RoadmapItem icon="🤖" title="Whisper AI Assistant" quarter="Q3 2026" status="available">
 
-Context-aware AI assistant that provides intelligent suggestions for requirement writing, gap analysis recommendations, and compliance best practices. Trained on medical device regulatory frameworks and software engineering standards.
+Context-aware in-platform AI assistant (**Whisper**), available from v3.2. Provides AI-detected compliance suggestions against the active version and a conversational chat that can read project data and propose changes for you to confirm. Grounded in medical device regulatory frameworks and software engineering standards. Future iterations will expand coverage and proactive guidance.
 
 </RoadmapItem>
 

--- a/docs/p4samd/security/roles_permissions.md
+++ b/docs/p4samd/security/roles_permissions.md
@@ -4,51 +4,31 @@ title: Roles and Permissions
 sidebar_label: Roles and Permissions
 ---
 
-P4SaMD v3 has its own role-based access control (RBAC) system, independent of any external platform. Roles are assigned at two levels: **Organization** and **Project**.
+P4SaMD v3 has its own role-based access control (RBAC) system, independent of any external platform. Roles are assigned at two levels: as an **organization (tenant) member** and as a **member of a specific project**. Both levels use the same five roles, assigned independently: a user's role in one project (or at the organization level) has no bearing on another.
 
-## Organization Roles
+## Roles
 
-Organization roles govern what a user can do at the organization level — managing members, settings, and projects.
-
-| Role | Description |
-|------|-------------|
-| **Organization Admin** | Full control over the organization: manage members, settings, integrations, feature toggles, and subscription. Can create and delete projects. |
-| **Organization Member** | Can view the organization's product list and enter projects they are a member of. Cannot change organization settings or create projects. |
-
-## Project Roles
-
-Project roles govern what a user can do within a specific project. A user must be explicitly added to a project to have access to it.
-
-| Role | Description |
-|------|-------------|
-| **Project Admin** | Full control within the project: manage team members, project settings, integrations, and all SDLC artifacts. Can release versions. |
-| **Maintainer** | Can create, edit, approve, and release most project artifacts (requirements, risks, tests, changes, versions). Cannot manage team membership or project settings. |
-| **Developer** | Can create and edit artifacts. Cannot approve, release, or delete items. |
-| **Reporter** | Read-only access to all project artifacts. Cannot modify anything. |
-| **Guest** | Read-only access to a limited subset of project information. |
+| Role | Summary |
+|------|---------|
+| **Admin** | Full control. Invite and remove members, change member roles, manage all settings, full read/write access to every SDLC section, and delete or archive the product. |
+| **Tech Team** | Create and edit work items in the design and implementation sections, review and approve specifications, and read all work items. |
+| **Business** | Create and manage work items such as requirements and risks, review and approve specifications, participate in product definition, and read the design and implementation sections. |
+| **QA** | Review and verify work items in the testing section, approve requirements and risk controls, access test plans and results, and read all SDLC sections. |
+| **Viewer** | Read-only access to all product content; browse requirements, design, and implementation. Cannot create, edit, or delete any work items. |
 
 ## Capabilities by Role
 
-The following table shows the key capabilities available to each project role.
+The full capability breakdown is shown in-product when you assign a role in the **Add Member** dialog (click **Show capabilities**). The capabilities are:
 
-| Capability | Guest | Reporter | Developer | Maintainer | Project Admin |
-|-----------|-------|----------|-----------|------------|---------------|
-| View requirements, risks, tests | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Create requirements | ❌ | ❌ | ✅ | ✅ | ✅ |
-| Edit requirements | ❌ | ❌ | ✅ | ✅ | ✅ |
-| Approve requirements | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Deprecate requirements | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Create risks | ❌ | ❌ | ✅ | ✅ | ✅ |
-| Approve risks | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Create and run test suites | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Delete test suites | ❌ | ❌ | ❌ | ❌ | ✅ |
-| Create and approve software items | ❌ | ❌ | ✅ | ✅ | ✅ |
-| Delete software items | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Generate and publish documentation | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Create new versions | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Release a version | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Manage project settings | ❌ | ❌ | ❌ | ❌ | ✅ |
-| Add / remove project members | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Role | Capabilities |
+|------|-------------|
+| **Admin** | • Invite and remove product members<br/>• Change member roles<br/>• Manage all product settings<br/>• Full read and write access to all SDLC sections<br/>• Delete or archive the product |
+| **Tech Team** | • Create and edit work items in design and implementation sections<br/>• Review and approve specifications<br/>• Read access to all the work items |
+| **Business** | • Create and manage work items like requirements and risks<br/>• Review and approve specifications<br/>• Participate in product definition activities<br/>• Read access to design and implementation sections |
+| **QA** | • Review and verify work items in testing section<br/>• Approve requirements and risk controls<br/>• Access test plans and test results<br/>• Read access to all SDLC sections |
+| **Viewer** | • Read-only access to all product content<br/>• Browse requirements, design, and implementation sections<br/>• Cannot create, edit, or delete any work items |
+
+Members are managed from the **Members** page — **Tenant Members** at the organization level and **Product Members** inside a project. See [Products & Projects](../handbook/products.mdx) for how to add and remove members.
 
 ## Authentication
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -137,7 +137,7 @@ const config = {
           includeCurrentVersion: true,
           versions: {
             current: {
-              label: "3.0.x (Current)",
+              label: "3.x (Current)",
               path: "",
               banner: "none"
             },

--- a/sidebars.json
+++ b/sidebars.json
@@ -66,6 +66,16 @@
           "type": "doc"
         },
         {
+          "id": "p4samd/handbook/whisper",
+          "label": "Whisper AI Assistant",
+          "type": "doc"
+        },
+        {
+          "id": "p4samd/handbook/ai_configuration",
+          "label": "AI Configuration",
+          "type": "doc"
+        },
+        {
           "label": "Brownfield Import",
           "type": "category",
           "items": [


### PR DESCRIPTION
## Summary

Consolidates the P4SaMD handbook to a single **v3.x** documentation version and documents everything shipped in the last two minors (**v3.1**, **v3.1.1**, and the upcoming **v3.2**).

Scope was derived from ground truth: the Configurations deployment manifests pin service image versions per release (v3.1.0 → backend/frontend 0.6.0; v3.2.0 → 0.7.0), and the user-facing diff was extracted from each service repo's git history across those tags.

## Version picker
- Relabel the current docs version **`3.0.x (Current)` → `3.x (Current)`** so all v3 minors collect into one documentation version (`docusaurus.config.js`).

## Release notes (cumulative, on the v3.x page)
- **v3.1** (11 Jun): Software Item lifecycle (Draft → Approved → Verified → Deprecated), tabbed Requirement & Software Item detail pages (Details / Traceability / History), **Product Members** management, sortable lists + stats, label suggestions, extended MCP coverage.
- **v3.1.1** (12 Jun): file storage migrated to **Google Cloud Storage** — ⚠️ *breaking*: previously uploaded files are not accessible.
- **v3.2** (upcoming): **Whisper AI Assistant** (compliance suggestions + chat with confirmable actions), **AI Configuration / LLM Profiles**, 17 MCP domain tools, AI-activity audit, LLM keys encrypted at rest.
- Roadmap: *Smart Insight AI Advisor* → **Whisper AI Assistant** (now available).

## Handbook
- **New page:** Whisper AI Assistant.
- **New page:** AI Configuration (LLM Profiles, AI-features toggle, available models, model discovery).
- **Roles & Permissions** corrected to the shipped roles — **Admin / Tech Team / Business / QA / Viewer** — with verbatim capability text (previous doc listed Maintainer/Developer/Reporter/Guest, which were never implemented).
- **Products & Projects** updated for the Product Members page.
- Whisper/AI surfaced in **Getting Started** and **Organizations**.
- New pages wired into the sidebar; new terms allowlisted in cspell.

## Scoping notes
- The v3.2 frontend cut includes model-picker / delete-chat (DEV runs `0.7.0-rc.9`, past the rc.4 tag).
- **User invitation / seat management** was *excluded* — backend exists only on an unmerged side branch with no frontend in the release cut.

## Verification
- `docusaurus build` passes (`onBrokenLinks: throw`), so all internal links/anchors resolve.
- New acronyms added to `.cspell.json` (cspell requires Node ≥22, not run locally).
- Note: `scripts/validate-links.js` reports errors, but it flags ~16 pages **including untouched pre-existing ones** — it doesn't resolve this handbook's relative-link convention and is not the effective gate (the Docusaurus build is).

https://claude.ai/code/session_01KKb5HTam8WJs3ycUqY7QxL