### PR TITLE
docs: installation polish + release-notes month clustering & roadmap subpage

### DIFF
--- a/301redirects.json
+++ b/301redirects.json
@@ -1,2 +1,14 @@
 {
+  "/docs/p4samd/handbook/getting_started": {
+    "destination": "/docs/p4samd/handbook/getting-started",
+    "addedOn": "2026-06-30"
+  },
+  "/docs/p4samd/handbook/version_management": {
+    "destination": "/docs/p4samd/handbook/version-management",
+    "addedOn": "2026-06-30"
+  },
+  "/docs/p4samd/handbook/ai_configuration": {
+    "destination": "/docs/p4samd/handbook/ai-configuration",
+    "addedOn": "2026-06-30"
+  }
 }

--- a/docs/p4samd/handbook/ai_configuration.md
+++ b/docs/p4samd/handbook/ai_configuration.md
@@ -2,6 +2,7 @@
 id: ai_configuration
 title: AI Configuration
 sidebar_label: AI Configuration
+slug: ai-configuration
 ---
 
 P4SaMD's AI capabilities — including the [Whisper AI Assistant](./whisper.md) and AI-powered compliance evaluation — are configured per organization by an administrator. This page explains how to enable AI features and connect your own LLM provider. AI configuration was introduced in **v3.2**.

--- a/docs/p4samd/handbook/getting_started.mdx
+++ b/docs/p4samd/handbook/getting_started.mdx
@@ -2,6 +2,7 @@
 id: getting_started
 title: Getting Started
 sidebar_label: Getting Started
+slug: getting-started
 ---
 
 import { StepGuide, Step, Prerequisites, Tip, NextSteps } from '@site/src/components/StepGuide';
@@ -76,7 +77,7 @@ Once inside a project, the left sidebar gives you access to the full set of tool
 | **AI Inventory** | Manage AI/ML components, model versions, and AI-specific compliance workflows (AI-Powered projects only) |
 
 <Tip>
-  Look for the **sparkles icon** in the top bar to open <strong>Whisper</strong>, the in-platform AI assistant. It surfaces compliance suggestions for the current version and answers questions in a chat. Whisper appears once an administrator enables AI features for your organization — see <a href="./ai_configuration">AI Configuration</a>.
+  Look for the **sparkles icon** in the top bar to open <strong>Whisper</strong>, the in-platform AI assistant. It surfaces compliance suggestions for the current version and answers questions in a chat. Whisper appears once an administrator enables AI features for your organization — see <a href="./ai-configuration">AI Configuration</a>.
 </Tip>
 
 </Step>

--- a/docs/p4samd/handbook/products.mdx
+++ b/docs/p4samd/handbook/products.mdx
@@ -33,5 +33,5 @@ At the organization level, the same page is shown as **Tenant Members** for mana
 <NextSteps items={[
   { icon: '📝', label: 'Work with requirements', to: './requirements' },
   { icon: '🔄', label: 'Run a Brownfield Import', to: './brownfield/overview' },
-  { icon: '📋', label: 'Manage versions', to: './version_management' },
+  { icon: '📋', label: 'Manage versions', to: './version-management' },
 ]} />

--- a/docs/p4samd/handbook/requirements.mdx
+++ b/docs/p4samd/handbook/requirements.mdx
@@ -51,5 +51,5 @@ P4SaMD automatically assesses the quality of each requirement based on completen
 Quality is re-evaluated automatically every time you create or update a requirement. While the new score is being computed, the badge is temporarily hidden. Once evaluation completes, the updated badge appears — no manual action is needed.
 
 <NextSteps items={[
-  { icon: '📋', label: 'Work with versions', to: './version_management' },
+  { icon: '📋', label: 'Work with versions', to: './version-management' },
 ]} />

--- a/docs/p4samd/handbook/version_management.mdx
+++ b/docs/p4samd/handbook/version_management.mdx
@@ -2,6 +2,7 @@
 id: version_management
 title: Version Management
 sidebar_label: Version Management
+slug: version-management
 ---
 
 import { NextSteps } from '@site/src/components/StepGuide';

--- a/docs/p4samd/installation/saas.mdx
+++ b/docs/p4samd/installation/saas.mdx
@@ -95,18 +95,47 @@ The table below shows which features are available on each subscription tier. **
 
 ---
 
-## Prerequisites
+## System Requirements
 
-Because SaaS is fully managed by Mia-Care, there is **nothing to install** and no servers, databases, or Kubernetes to provision — that is all handled for you. The prerequisites below are about what you need on your side to onboard and use the platform.
+P4SaMD SaaS is a fully managed, browser-based web application. There is **nothing to install** and no servers, databases, or Kubernetes for you to provision — that is all handled by Mia-Care. (Infrastructure requirements such as Kubernetes, PostgreSQL, object storage, and an OIDC provider apply only to [On-premise](./on-premise.mdx) deployments.) The only requirements are on the end-user device.
+
+> **Applies to:** P4SaMD v3.x &nbsp;·&nbsp; **Last updated:** 30 June 2026
+
+### Supported Web Browsers
+
+P4SaMD supports recent desktop browsers. The minimum supported versions are:
+
+| Browser | Minimum version | Platforms |
+|---|---|---|
+| Google Chrome | 114 or later | Windows, macOS, Linux |
+| Microsoft Edge | 114 or later | Windows, macOS |
+| Mozilla Firefox | 115 (ESR) or later | Windows, macOS, Linux |
+| Apple Safari | 16.4 or later | macOS, iOS / iPadOS |
+
+Browsers and versions not listed above (including Microsoft Internet Explorer) are **not officially supported**. Using an unsupported or outdated browser may cause parts of the interface to render or behave incorrectly. Keeping your browser updated to the latest available version is recommended.
+
+### Client-Side Requirements
+
+| Requirement | Minimum |
+|---|---|
+| Operating system | Windows 10 or later, macOS 12 or later, or a current mainstream Linux distribution; iOS / iPadOS 16+ or Android 11+ for tablet/mobile access |
+| Screen resolution | 1280 × 720 (1366 × 768 or higher recommended) |
+| JavaScript | Must be enabled in the browser |
+| Cookies | First-party cookies must be allowed (used to maintain your authenticated session) |
+| Network | A stable broadband internet connection — **5 Mbps or faster recommended**. Outbound HTTPS (port 443) to your P4SaMD instance URL; if your network restricts egress, allowlist the instance domain. |
+
+:::tip Sharing with customers
+The two tables above are self-contained: they can be copied directly into customer communications as the official P4SaMD SaaS system requirements, without needing the rest of this document.
+:::
+
+## Onboarding Prerequisites
+
+Beyond the system requirements above, onboarding a new SaaS organization requires only a few things on your side.
 
 ### Mandatory
 
-These are needed for any SaaS plan.
-
 | Requirement | Details |
 |---|---|
-| **Modern web browser** | A current version of Chrome, Edge, Firefox, or Safari (last two major releases). P4SaMD is a web application; no desktop client is required. |
-| **Network access** | Outbound HTTPS (port 443) to your P4SaMD instance URL. If your network restricts egress, allowlist the instance domain. |
 | **Business email** | A reachable email address per user, for invitations, notifications, and password resets. Ensure mail from Mia-Care's sending domain is not blocked by your spam filters. |
 | **Organization administrator** | A named person to complete the initial organization setup wizard and manage members, roles, and settings. |
 | **Subscription plan** | An active subscription agreement with the plan tier that covers the features you need (see the [plan comparison](#plan-comparison) above). |

--- a/docs/p4samd/installation/saas.mdx
+++ b/docs/p4samd/installation/saas.mdx
@@ -95,6 +95,35 @@ The table below shows which features are available on each subscription tier. **
 
 ---
 
+## Prerequisites
+
+Because SaaS is fully managed by Mia-Care, there is **nothing to install** and no servers, databases, or Kubernetes to provision — that is all handled for you. The prerequisites below are about what you need on your side to onboard and use the platform.
+
+### Mandatory
+
+These are needed for any SaaS plan.
+
+| Requirement | Details |
+|---|---|
+| **Modern web browser** | A current version of Chrome, Edge, Firefox, or Safari (last two major releases). P4SaMD is a web application; no desktop client is required. |
+| **Network access** | Outbound HTTPS (port 443) to your P4SaMD instance URL. If your network restricts egress, allowlist the instance domain. |
+| **Business email** | A reachable email address per user, for invitations, notifications, and password resets. Ensure mail from Mia-Care's sending domain is not blocked by your spam filters. |
+| **Organization administrator** | A named person to complete the initial organization setup wizard and manage members, roles, and settings. |
+| **Subscription plan** | An active subscription agreement with the plan tier that covers the features you need (see the [plan comparison](#plan-comparison) above). |
+
+### Optional (plan-dependent)
+
+These unlock specific capabilities and are only needed if you intend to use the corresponding feature.
+
+| Requirement | Needed for | Details |
+|---|---|---|
+| **OIDC / SAML identity provider** | Single Sign-On (Professional plan and above) | Okta, Microsoft Entra ID, Auth0, Google Workspace, or any OIDC / SAML 2.0–compliant provider. Without SSO, P4SaMD manages credentials for you. |
+| **Custom domain + DNS control** | Custom domain (Dedicated SaaS, Professional plan and above) | A DNS record you control (e.g. `samd.yourcompany.com`) and authorization to validate it so a TLS certificate can be issued. |
+| **Data-residency decision** | Regional data hosting | Choose the **EU** or **US** region at provisioning. Dedicated SaaS supports a configurable region. |
+| **Egress IP ranges** | IP allowlist (Enterprise plan) | The public IP ranges your users connect from, if you want to restrict access to your organization to known networks. |
+
+---
+
 ## Getting Access
 
 To create a new SaaS organization, contact [Mia-Care](https://mia-care.io) or speak to your account representative. Provisioning typically completes within one business day for multi-tenant and three to five business days for dedicated environments.

--- a/docs/p4samd/overview.md
+++ b/docs/p4samd/overview.md
@@ -78,6 +78,6 @@ P4SaMD integrates with the tools your team already uses:
 
 ## Next Steps
 
-- [Get started with P4SaMD →](./handbook/getting_started)
+- [Get started with P4SaMD →](./handbook/getting-started)
 - [Read the FAQ →](./faq)
 - [See what's new in v3 →](./release-notes/v3.0)

--- a/docs/p4samd/release-notes/roadmap.mdx
+++ b/docs/p4samd/release-notes/roadmap.mdx
@@ -1,0 +1,63 @@
+---
+id: roadmap
+title: Product Roadmap
+sidebar_label: Product Roadmap
+---
+
+import { Roadmap, RoadmapItem } from '@site/src/components/Roadmap';
+
+P4SaMD v3 is an evolving platform. The features below are actively in development and will roll out in upcoming minor releases throughout 2026 and beyond.
+
+<Roadmap>
+
+<RoadmapItem icon="⚠️" title="Risk Management" quarter="Q2 2026" status="available">
+
+ISO 14971-compliant risk management with hazard identification, 5×5 severity/probability risk matrix, automatic risk level computation (Unacceptable / ALARP / Acceptable), control measures, residual risk tracking, and a full status lifecycle. Bidirectional traceability between risks, requirements, and verification evidence. CSV import and export included.
+
+</RoadmapItem>
+
+<RoadmapItem icon="🤖" title="Whisper AI Assistant" quarter="Q3 2026" status="available" beta>
+
+Context-aware in-platform AI assistant (**Whisper**), available in **beta** from v3.2. Provides AI-detected compliance suggestions against the active version and a conversational chat that can read project data and propose changes for you to confirm. Grounded in medical device regulatory frameworks and software engineering standards. Future iterations will expand coverage and proactive guidance.
+
+</RoadmapItem>
+
+<RoadmapItem icon="✅" title="Verification & Validation Execution" quarter="Q3 2026" status="in-progress">
+
+Execute test plans directly in P4SaMD with test case assignment, execution tracking, evidence attachment, and pass/fail reporting. IEC 62304-aligned V&V documentation generation with full traceability to requirements and design.
+
+</RoadmapItem>
+
+<RoadmapItem icon="🔄" title="SDLC Workflow Orchestrator" quarter="Q4 2026" status="soon">
+
+Automated workflow engine that coordinates development activities across the software lifecycle. CI/CD pipeline integration for automated test triggering, build verification, and compliance gate enforcement.
+
+</RoadmapItem>
+
+<RoadmapItem icon="📄" title="Documentation Engine" quarter="Q4 2026" status="soon">
+
+Auto-generated compliance documentation including Software Development Plans, Risk Management Reports, Verification Reports, and Technical Files. Template-based output with PDF export and regulatory submission packaging.
+
+</RoadmapItem>
+
+<RoadmapItem icon="🏗️" title="System Design & Architecture" quarter="Q1 2027" status="planned">
+
+System architecture modeling with component diagrams, interface specifications, and design rationale capture. Automated generation of Software Architecture Documents and Detailed Design Specifications aligned to IEC 62304 requirements.
+
+</RoadmapItem>
+
+<RoadmapItem icon="📦" title="BOM Management & SBOM" quarter="Q1 2027" status="planned">
+
+Bill of Materials management for software components, dependencies, and SOUP items. Automated SBOM generation in SPDX and CycloneDX formats. License compliance tracking and vulnerability correlation.
+
+</RoadmapItem>
+
+<RoadmapItem icon="📊" title="Post-Market Surveillance" quarter="Q2 2027" status="planned">
+
+Post-market monitoring dashboard with adverse event tracking, complaint management, field action coordination, and trend analysis. Integration capabilities with vigilance reporting systems and regulatory authority portals.
+
+</RoadmapItem>
+
+</Roadmap>
+
+Subscribe to release notifications or contact Mia-Care for roadmap updates and feature access.

--- a/docs/p4samd/release-notes/v3.0.mdx
+++ b/docs/p4samd/release-notes/v3.0.mdx
@@ -2,20 +2,140 @@
 id: v3.0
 title: Release Notes — Current (v3.x)
 sidebar_label: Current (v3.x)
+toc_max_heading_level: 2
 ---
 
 import { FeatureBox, FeatureGrid } from '@site/src/components/FeatureBox';
-import { Roadmap, RoadmapItem } from '@site/src/components/Roadmap';
 
-## P4SaMD v3.0
+Releases are grouped by the month they shipped, newest first.
 
-**Release date**: 26 May 2026
+## June 2026 (v3.1.0 – v3.2.0)
 
-Version 3.0 is a complete re-architecture of P4SaMD. This release marks the beginning of the v3 product line. It delivers a standalone platform that operates independently of any third-party software infrastructure.
+Three releases shipped in June: the **Whisper AI Assistant** and AI configuration (v3.2.0), a storage migration (v3.1.1), and the System Design lifecycle and team-administration work (v3.1.0).
+
+### P4SaMD v3.2.0 — 30 June 2026
+
+Version 3.2 introduces **Whisper**, the in-platform AI assistant, together with the tenant-level **AI configuration** that powers it. This is the first release of the AI advisor capability previously on the roadmap.
+
+<FeatureGrid>
+
+<FeatureBox icon="🤖" title="Whisper AI Assistant">
+
+A new AI assistant available on every project page, opened from the sparkles icon in the top bar. Whisper surfaces **compliance suggestions** for the active version and offers an interactive **chat** that can read your project and propose changes for you to confirm.
+
+</FeatureBox>
+
+<FeatureBox icon="🔎" title="Compliance Suggestions">
+
+Whisper analyzes your active version and lists AI-detected compliance findings, sorted by priority, each with a normative reference, reasoning, remediation steps, and a confidence indicator. You can run a fresh analysis on demand and dismiss, resolve, or reopen each finding.
+
+</FeatureBox>
+
+<FeatureBox icon="💬" title="Conversational Chat with Confirmable Actions">
+
+Ask Whisper questions in natural language and get streamed answers. When the assistant proposes a change to your data (for example creating a requirement), it presents a **Confirm / Decline** card — nothing is changed without your explicit approval, and every confirmed or declined action is recorded in the audit log.
+
+</FeatureBox>
+
+<FeatureBox icon="⚙️" title="AI Configuration & LLM Profiles">
+
+Administrators can enable AI features per organization and assign an LLM provider and model to each workload — **Chat** and **Evaluation** — from a new **LLM Profiles** settings page, with live credential validation. Providers can expose an allow-list of selectable chat models, and the live model list can be discovered directly from the provider.
+
+</FeatureBox>
+
+</FeatureGrid>
+
+:::note Beta
+The Whisper AI Assistant ships in **beta** in v3.2.0. It is available for use, with coverage and proactive guidance expanding in upcoming releases.
+:::
+
+#### New: Whisper AI Assistant
+
+The Whisper panel slides in from the right (and can be expanded to full page) and shows the current project and version context. Its two modes are:
+
+- **Compliance Suggestions** — AI-detected findings for the active version. The top-bar badge shows the count of open findings. Each finding opens a detail drawer (priority, category, normative reference, description, reasoning, remediation steps, confidence). **Analyze now** triggers a fresh analysis; findings can be **dismissed** or **resolved** (with an optional reason and an undo), and a freshness label shows how recently the analysis ran.
+- **Chat** — a conversational assistant with token-by-token streaming, persisted conversations you can resume or delete, and a per-message model picker. Proposed mutating actions require **Confirm / Decline**, and assistant messages are clearly marked as AI-generated.
+
+See the [Whisper AI Assistant](../handbook/whisper.md) handbook page for the full walkthrough.
+
+#### New: AI Configuration
+
+A new **LLM Profiles** page under Settings (Admin-only) lets you configure AI provider credentials separately for the **Chat** and **Evaluation** workloads — so you can, for example, use one provider for chat and another for compliance evaluation. AI features are gated behind a per-organization **AI features** toggle. See [AI Configuration](../handbook/ai_configuration.md) for details.
+
+#### For developers
+
+- The MCP tool catalog grew to **17 tools**, adding risk-management and software-item domain tools, now shared as a single source of truth with the Whisper agent.
+- AI assistant activity (confirmed/declined actions and conversation creation) is now written to the audit log.
+
+#### Security
+
+- LLM provider API keys are now stored **encrypted at rest (AES-256-GCM)** in the database, removing the previous external secrets-manager dependency.
+
+### P4SaMD v3.1.1 — 12 June 2026
+
+A focused maintenance release that migrated file storage to a managed object store.
+
+#### Changed: File storage migrated to Google Cloud Storage
+
+The self-hosted file storage backend was replaced with a managed **Google Cloud Storage (GCS)** bucket across all environments. This removes a single point of failure (an unreplicated storage pod) and the risk of data loss on restart, and simplifies credential management.
+
+:::warning Breaking change
+**Files uploaded before this release are not accessible afterward.** No data was migrated between the old storage and the new GCS bucket, so any previously uploaded files — for example design files in the System Design section — must be re-uploaded. This was an accepted trade-off given the platform's current internal-only audience and the small volume of stored data.
+:::
+
+### P4SaMD v3.1.0 — 11 June 2026
+
+Version 3.1 deepens the native SDLC artifact management introduced in v3.0, with a focus on the **System Design** workspace, formal lifecycle controls, and team administration.
+
+#### New: Software Item Lifecycle (System Design)
+
+Software items now carry a formal IEC 62304-aligned lifecycle status: **Draft → Approved → Verified**, plus a terminal **Deprecated** state. You move items through the lifecycle from the software item detail view:
+
+- **Approve** an item once its design is ready (requires the Admin role).
+- **Verify** an approved item once it has supporting evidence.
+- **Revert to Draft** to reopen an Approved or Verified item for further work.
+- **Deprecate** an item that is no longer in use. Deprecation is one-way, requires a written rationale (at least 10 characters), and is only available for items belonging to a released version.
+
+Items that belong to a **released** version are protected: they cannot be deleted, and editing them requires an edit rationale that is recorded in the item's history.
+
+#### New: Tabbed Detail Pages for Requirements and Software Items
+
+Requirements and software items now open in a dedicated detail page with three tabs:
+
+- **Details** — view and inline-edit all fields, including the parent/child hierarchy and a system-metadata block (created/updated/approved by, with timestamps).
+- **Traceability** — see linked risks, tests, software items, and change requests, plus a risk-coverage indicator and a link to the traceability matrix.
+- **History** — a chronological audit trail of every create, edit, status transition, and deletion, now showing the human-readable name of the person who made each change.
+
+#### New: Product Members Management
+
+Each project gets a **Members** page (shown as **Product Members** inside a project, **Tenant Members** at the organization level) for managing who has access and at what role. The page includes a member table with search and role filtering, a stats panel, and an **Add Member** dialog with an expandable per-role capability breakdown. Removing a member is guarded so you cannot remove the last Admin. See [Roles and Permissions](../security/roles_permissions.md) for the full role model.
+
+#### Improved
+
+- Requirement and software item lists are now **sortable** and show a stats bar; requirements can be sorted by their display ID.
+- Label entry now offers **autocomplete suggestions** instead of a separate single-label filter.
+- Larger design files can be uploaded to software items without hitting a size limit.
+
+#### Fixed
+
+- Switching organization now cancels in-flight requests and clears tenant-scoped cached data, so screens no longer briefly show data from the previously selected organization.
+- Corrected sort ordering on the Risk and Software Item lists.
+
+#### For developers: extended MCP coverage
+
+The bundled MCP server gained broad new read/write coverage (requirement lifecycle transitions, full risk register management, traceability links, software item browsing, version management, and design-file access), so external AI assistants and coding agents can operate on project data without REST access.
 
 ---
 
-### What's New
+## May 2026 (v3.0.x)
+
+The v3 product line launched in May with v3.0.0, followed by a series of v3.0.x patch updates.
+
+### P4SaMD v3.0.0 — 26 May 2026
+
+Version 3.0 is a complete re-architecture of P4SaMD. This release marks the beginning of the v3 product line. It delivers a standalone platform that operates independently of any third-party software infrastructure.
+
+#### What's New
 
 <FeatureGrid>
 
@@ -75,17 +195,13 @@ Workspace versions provide IEC 62304-aligned configuration management. Draft ver
 
 </FeatureGrid>
 
----
-
-### Upgrading from v2
+#### Upgrading from v2
 
 P4SaMD v3 is a new platform. There is no direct in-place migration path from v2. Organizations moving from v2 are recommended to use the **Brownfield Import** feature to onboard their existing projects into the v3 platform. Contact Mia-Care for migration support.
 
----
+### Patch updates — late May 2026 (v3.0.x)
 
-## May 2026 Updates
-
-### New: Risk Management
+#### New: Risk Management
 
 P4SaMD now includes a full **Risk Management** module compliant with ISO 14971. You can create, assess, mitigate, and track risks directly in the platform with:
 
@@ -98,23 +214,23 @@ P4SaMD now includes a full **Risk Management** module compliant with ISO 14971. 
 
 See the [Risk Management handbook page](../handbook/risks.md) for full details.
 
-### Improved: Requirement Quality Assessment
+#### Improved: Requirement Quality Assessment
 
 Requirement quality is now assessed automatically every time you create or edit a requirement. Quality badges (Very High, High, Low) update in real time without any manual trigger. While a new score is being computed, the badge is temporarily hidden until the updated assessment is ready.
 
-### Improved: Brownfield Evaluation Pipeline
+#### Improved: Brownfield Evaluation Pipeline
 
 The Brownfield evaluation now provides real-time progress tracking through four processing phases (Document Preparation, Extraction, Payload Crafting, Evaluation). After completion, two new metrics are available: **Compliance Health Score** and **Traceability Coverage**. You can also export evaluation results in PDF and CSV formats.
 
-### Improved: Requirements Import
+#### Improved: Requirements Import
 
 CSV import now provides detailed per-row validation feedback. Valid rows are imported even when other rows contain errors (partial-success behavior), so you no longer need to fix all issues in a file before any requirements are created.
 
-### Changed: Default Workspace Version Name
+#### Changed: Default Workspace Version Name
 
 New projects now start with a default workspace version named **main** (previously `v1.0`).
 
-### Patch Fixes
+#### Patch Fixes
 
 - Fixed requirements type filter where selecting PRS or SRS showed items of the opposite type
 - Fixed requirements export where parent display IDs were not resolved correctly when parent items were excluded by filters
@@ -122,181 +238,8 @@ New projects now start with a default workspace version named **main** (previous
 
 ---
 
-## P4SaMD v3.1
-
-**Release date**: 11 June 2026
-
-Version 3.1 deepens the native SDLC artifact management introduced in v3.0, with a focus on the **System Design** workspace, formal lifecycle controls, and team administration.
-
-### New: Software Item Lifecycle (System Design)
-
-Software items now carry a formal IEC 62304-aligned lifecycle status: **Draft → Approved → Verified**, plus a terminal **Deprecated** state. You move items through the lifecycle from the software item detail view:
-
-- **Approve** an item once its design is ready (requires the Admin role).
-- **Verify** an approved item once it has supporting evidence.
-- **Revert to Draft** to reopen an Approved or Verified item for further work.
-- **Deprecate** an item that is no longer in use. Deprecation is one-way, requires a written rationale (at least 10 characters), and is only available for items belonging to a released version.
-
-Items that belong to a **released** version are protected: they cannot be deleted, and editing them requires an edit rationale that is recorded in the item's history.
-
-### New: Tabbed Detail Pages for Requirements and Software Items
-
-Requirements and software items now open in a dedicated detail page with three tabs:
-
-- **Details** — view and inline-edit all fields, including the parent/child hierarchy and a system-metadata block (created/updated/approved by, with timestamps).
-- **Traceability** — see linked risks, tests, software items, and change requests, plus a risk-coverage indicator and a link to the traceability matrix.
-- **History** — a chronological audit trail of every create, edit, status transition, and deletion, now showing the human-readable name of the person who made each change.
-
-### New: Product Members Management
-
-Each project gets a **Members** page (shown as **Product Members** inside a project, **Tenant Members** at the organization level) for managing who has access and at what role. The page includes a member table with search and role filtering, a stats panel, and an **Add Member** dialog with an expandable per-role capability breakdown. Removing a member is guarded so you cannot remove the last Admin. See [Roles and Permissions](../security/roles_permissions.md) for the full role model.
-
-### Improved
-
-- Requirement and software item lists are now **sortable** and show a stats bar; requirements can be sorted by their display ID.
-- Label entry now offers **autocomplete suggestions** instead of a separate single-label filter.
-- Larger design files can be uploaded to software items without hitting a size limit.
-
-### Fixed
-
-- Switching organization now cancels in-flight requests and clears tenant-scoped cached data, so screens no longer briefly show data from the previously selected organization.
-- Corrected sort ordering on the Risk and Software Item lists.
-
-### For developers: extended MCP coverage
-
-The bundled MCP server gained broad new read/write coverage (requirement lifecycle transitions, full risk register management, traceability links, software item browsing, version management, and design-file access), so external AI assistants and coding agents can operate on project data without REST access.
-
----
-
-## P4SaMD v3.1.1
-
-**Release date**: 12 June 2026
-
-A focused maintenance release that migrated file storage to a managed object store.
-
-### Changed: File storage migrated to Google Cloud Storage
-
-The self-hosted file storage backend was replaced with a managed **Google Cloud Storage (GCS)** bucket across all environments. This removes a single point of failure (an unreplicated storage pod) and the risk of data loss on restart, and simplifies credential management.
-
-:::warning Breaking change
-**Files uploaded before this release are not accessible afterward.** No data was migrated between the old storage and the new GCS bucket, so any previously uploaded files — for example design files in the System Design section — must be re-uploaded. This was an accepted trade-off given the platform's current internal-only audience and the small volume of stored data.
+:::tip Looking ahead
+For features planned for upcoming releases, see the [Product Roadmap](./roadmap.mdx).
 :::
 
----
-
-## P4SaMD v3.2
-
-**Expected: July 2026**
-
-Version 3.2 introduces **Whisper**, the in-platform AI assistant, together with the tenant-level **AI configuration** that powers it. This is the first release of the AI advisor capability previously on the roadmap.
-
-<FeatureGrid>
-
-<FeatureBox icon="🤖" title="Whisper AI Assistant">
-
-A new AI assistant available on every project page, opened from the sparkles icon in the top bar. Whisper surfaces **compliance suggestions** for the active version and offers an interactive **chat** that can read your project and propose changes for you to confirm.
-
-</FeatureBox>
-
-<FeatureBox icon="🔎" title="Compliance Suggestions">
-
-Whisper analyzes your active version and lists AI-detected compliance findings, sorted by priority, each with a normative reference, reasoning, remediation steps, and a confidence indicator. You can run a fresh analysis on demand and dismiss, resolve, or reopen each finding.
-
-</FeatureBox>
-
-<FeatureBox icon="💬" title="Conversational Chat with Confirmable Actions">
-
-Ask Whisper questions in natural language and get streamed answers. When the assistant proposes a change to your data (for example creating a requirement), it presents a **Confirm / Decline** card — nothing is changed without your explicit approval, and every confirmed or declined action is recorded in the audit log.
-
-</FeatureBox>
-
-<FeatureBox icon="⚙️" title="AI Configuration & LLM Profiles">
-
-Administrators can enable AI features per organization and assign an LLM provider and model to each workload — **Chat** and **Evaluation** — from a new **LLM Profiles** settings page, with live credential validation. Providers can expose an allow-list of selectable chat models, and the live model list can be discovered directly from the provider.
-
-</FeatureBox>
-
-</FeatureGrid>
-
-### New: Whisper AI Assistant
-
-The Whisper panel slides in from the right (and can be expanded to full page) and shows the current project and version context. Its two modes are:
-
-- **Compliance Suggestions** — AI-detected findings for the active version. The top-bar badge shows the count of open findings. Each finding opens a detail drawer (priority, category, normative reference, description, reasoning, remediation steps, confidence). **Analyze now** triggers a fresh analysis; findings can be **dismissed** or **resolved** (with an optional reason and an undo), and a freshness label shows how recently the analysis ran.
-- **Chat** — a conversational assistant with token-by-token streaming, persisted conversations you can resume or delete, and a per-message model picker. Proposed mutating actions require **Confirm / Decline**, and assistant messages are clearly marked as AI-generated.
-
-See the [Whisper AI Assistant](../handbook/whisper.md) handbook page for the full walkthrough.
-
-### New: AI Configuration
-
-A new **LLM Profiles** page under Settings (Admin-only) lets you configure AI provider credentials separately for the **Chat** and **Evaluation** workloads — so you can, for example, use one provider for chat and another for compliance evaluation. AI features are gated behind a per-organization **AI features** toggle. See [AI Configuration](../handbook/ai_configuration.md) for details.
-
-### For developers
-
-- The MCP tool catalog grew to **17 tools**, adding risk-management and software-item domain tools, now shared as a single source of truth with the Whisper agent.
-- AI assistant activity (confirmed/declined actions and conversation creation) is now written to the audit log.
-
-### Security
-
-- LLM provider API keys are now stored **encrypted at rest (AES-256-GCM)** in the database, removing the previous external secrets-manager dependency.
-
----
-
-## Product Roadmap
-
-P4SaMD v3 is an evolving platform. The features below are actively in development and will roll out in upcoming minor releases throughout 2026 and beyond:
-
-<Roadmap>
-
-<RoadmapItem icon="⚠️" title="Risk Management" quarter="Q2 2026" status="available">
-
-ISO 14971-compliant risk management with hazard identification, 5×5 severity/probability risk matrix, automatic risk level computation (Unacceptable / ALARP / Acceptable), control measures, residual risk tracking, and a full status lifecycle. Bidirectional traceability between risks, requirements, and verification evidence. CSV import and export included.
-
-</RoadmapItem>
-
-<RoadmapItem icon="✅" title="Verification & Validation Execution" quarter="Q3 2026" status="in-progress">
-
-Execute test plans directly in P4SaMD with test case assignment, execution tracking, evidence attachment, and pass/fail reporting. IEC 62304-aligned V&V documentation generation with full traceability to requirements and design.
-
-</RoadmapItem>
-
-<RoadmapItem icon="🔄" title="SDLC Workflow Orchestrator" quarter="Q4 2026" status="soon">
-
-Automated workflow engine that coordinates development activities across the software lifecycle. CI/CD pipeline integration for automated test triggering, build verification, and compliance gate enforcement.
-
-</RoadmapItem>
-
-<RoadmapItem icon="📄" title="Documentation Engine" quarter="Q4 2026" status="soon">
-
-Auto-generated compliance documentation including Software Development Plans, Risk Management Reports, Verification Reports, and Technical Files. Template-based output with PDF export and regulatory submission packaging.
-
-</RoadmapItem>
-
-<RoadmapItem icon="🏗️" title="System Design & Architecture" quarter="Q1 2027" status="planned">
-
-System architecture modeling with component diagrams, interface specifications, and design rationale capture. Automated generation of Software Architecture Documents and Detailed Design Specifications aligned to IEC 62304 requirements.
-
-</RoadmapItem>
-
-<RoadmapItem icon="📦" title="BOM Management & SBOM" quarter="Q1 2027" status="planned">
-
-Bill of Materials management for software components, dependencies, and SOUP items. Automated SBOM generation in SPDX and CycloneDX formats. License compliance tracking and vulnerability correlation.
-
-</RoadmapItem>
-
-<RoadmapItem icon="🤖" title="Whisper AI Assistant" quarter="Q3 2026" status="available">
-
-Context-aware in-platform AI assistant (**Whisper**), available from v3.2. Provides AI-detected compliance suggestions against the active version and a conversational chat that can read project data and propose changes for you to confirm. Grounded in medical device regulatory frameworks and software engineering standards. Future iterations will expand coverage and proactive guidance.
-
-</RoadmapItem>
-
-<RoadmapItem icon="📊" title="Post-Market Surveillance" quarter="Q2 2027" status="planned">
-
-Post-market monitoring dashboard with adverse event tracking, complaint management, field action coordination, and trend analysis. Integration capabilities with vigilance reporting systems and regulatory authority portals.
-
-</RoadmapItem>
-
-</Roadmap>
-
-Each minor release will include detailed documentation of new capabilities as they become available. Subscribe to release notifications or contact Mia-Care for roadmap updates and feature access
-Release notes for each subsequent minor version will document new capabilities as they become available.
+Release notes for each subsequent release will be documented here as they become available.

--- a/docs/p4samd/tutorials/implementing-iec-62304.mdx
+++ b/docs/p4samd/tutorials/implementing-iec-62304.mdx
@@ -296,7 +296,7 @@ Generated documents automatically include version numbers, approval signatures, 
     {
       title: "Continuous Compliance",
       description: "Learn how to manage ongoing development with version control and change management",
-      link: "../handbook/version_management"
+      link: "../handbook/version-management"
     },
     {
       title: "Risk Management Best Practices",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,8 +8,12 @@ const config = {
   url: "https://mia-care.github.com",
   baseUrl: "/",
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: 'throw',
   onBrokenAnchors: 'warn',
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'throw',
+    },
+  },
   favicon: "img/favicon.ico",
   organizationName: "Mia-Care",
   projectName: "p4samd-handbook",
@@ -105,7 +109,7 @@ const config = {
             },
             {
               label: "Privacy Policy",
-              href: "https://mia-care.io/wp-content/uploads/2021/07/Mia-Care_Privacy_Policy_EN.pdf",
+              href: "https://mia-care.io/privacy-policy",
             },
           ],
         },

--- a/sidebars.json
+++ b/sidebars.json
@@ -6,11 +6,6 @@
       "type": "doc"
     },
     {
-      "id": "p4samd/faq",
-      "label": "FAQ",
-      "type": "doc"
-    },
-    {
       "label": "Installation",
       "type": "category",
       "items": [
@@ -109,6 +104,11 @@
           "type": "doc"
         }
       ]
+    },
+    {
+      "id": "p4samd/faq",
+      "label": "FAQ",
+      "type": "doc"
     },
     {
       "label": "Release Notes",

--- a/sidebars.json
+++ b/sidebars.json
@@ -130,6 +130,11 @@
           "type": "doc"
         },
         {
+          "id": "p4samd/release-notes/roadmap",
+          "label": "Product Roadmap",
+          "type": "doc"
+        },
+        {
           "id": "p4samd/release_notes",
           "label": "Archived (v2.x)",
           "type": "doc"

--- a/src/components/DeploymentTable/index.js
+++ b/src/components/DeploymentTable/index.js
@@ -38,6 +38,7 @@ export function DeploymentTable({ columns, groups, highlight = [] }) {
 
   return (
     <div className={styles.wrapper}>
+      <div className={styles.scroll}>
       <table className={styles.table}>
         <thead>
           <tr>
@@ -88,6 +89,7 @@ export function DeploymentTable({ columns, groups, highlight = [] }) {
           ))}
         </tbody>
       </table>
+      </div>
     </div>
   );
 }

--- a/src/components/DeploymentTable/styles.module.css
+++ b/src/components/DeploymentTable/styles.module.css
@@ -1,9 +1,16 @@
 /* ─── Wrapper ──────────────────────────────────────────────── */
 .wrapper {
-  overflow-x: auto;
   margin: 2rem 0;
   border-radius: 10px;
   border: 1px solid var(--ifm-toc-border-color);
+  /* Clip cell backgrounds (e.g. highlighted columns) to the rounded corners */
+  overflow: hidden;
+}
+
+/* Inner scroll container keeps horizontal scrolling on narrow screens while
+   the wrapper clips the rounded corners. */
+.scroll {
+  overflow-x: auto;
 }
 
 /* ─── Table ────────────────────────────────────────────────── */

--- a/src/components/Roadmap/index.js
+++ b/src/components/Roadmap/index.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import styles from './styles.module.css';
 
-export function RoadmapItem({ icon, title, quarter, status = 'planned', children }) {
+export function RoadmapItem({ icon, title, quarter, status = 'planned', beta = false, children }) {
   const statusLabels = {
+    'available': 'Available',
     'in-progress': 'In Development',
     'planned': 'Planned',
     'soon': 'Coming Soon'
@@ -24,6 +25,7 @@ export function RoadmapItem({ icon, title, quarter, status = 'planned', children
               <span className={`${styles.statusBadge} ${styles[`status_${status}`]}`}>
                 {statusLabels[status]}
               </span>
+              {beta && <span className={styles.betaBadge}>Beta</span>}
             </div>
           </div>
         </div>

--- a/src/components/Roadmap/styles.module.css
+++ b/src/components/Roadmap/styles.module.css
@@ -32,6 +32,12 @@
   margin-top: 0.5rem;
 }
 
+.timelineDot.status_available {
+  border-color: #16a34a;
+  background: #16a34a;
+  box-shadow: 0 0 0 4px rgba(22, 163, 74, 0.1);
+}
+
 .timelineDot.status_in-progress {
   border-color: #2563eb;
   background: #2563eb;
@@ -109,9 +115,25 @@
   border-radius: 12px;
 }
 
+.statusBadge.status_available {
+  background: rgba(22, 163, 74, 0.1);
+  color: #16a34a;
+}
+
 .statusBadge.status_in-progress {
   background: rgba(37, 99, 235, 0.1);
   color: #2563eb;
+}
+
+.betaBadge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 0.25rem 0.625rem;
+  border-radius: 12px;
+  background: rgba(217, 119, 6, 0.12);
+  color: #d97706;
 }
 
 .statusBadge.status_soon {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,7 +17,7 @@ const handbookSections = [
   {
     title: "Getting Started",
     icon: "🚀",
-    href: "/docs/p4samd/handbook/getting_started",
+    href: "/docs/p4samd/handbook/getting-started",
     description:
       "Log in, select your organization, and navigate the platform for the first time.",
   },
@@ -92,7 +92,7 @@ const v3Features = [
     tag: "Self-Service",
     title: "Self-Service Configuration",
     body: "Organizations configure projects, integrations, and settings autonomously — without requiring Mia-Care to intervene.",
-    link: "/docs/p4samd/handbook/getting_started",
+    link: "/docs/p4samd/handbook/getting-started",
   },
 ];
 

--- a/src/theme/DocVersionBanner/index.js
+++ b/src/theme/DocVersionBanner/index.js
@@ -1,0 +1,143 @@
+/**
+ * Swizzled (ejected) from @docusaurus/theme-classic.
+ *
+ * Customization: the "latest version" link in the unmaintained/unreleased
+ * version banner always points to the Handbook "Getting Started" page in the
+ * latest version, instead of trying to resolve the same doc path in the latest
+ * version. This avoids 404s when a page that exists in an old version (e.g.
+ * /reports) no longer exists in the current version. (MCRDP4S3-774)
+ */
+import React from 'react';
+import clsx from 'clsx';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Link from '@docusaurus/Link';
+import Translate from '@docusaurus/Translate';
+import {
+  useActivePlugin,
+  useDocVersionSuggestions,
+} from '@docusaurus/plugin-content-docs/client';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import {
+  useDocsPreferredVersion,
+  useDocsVersion,
+} from '@docusaurus/plugin-content-docs/client';
+
+// Stable landing page the banner should always link to in the latest version.
+const LATEST_LANDING_DOC_ID = 'p4samd/handbook/getting_started';
+
+function UnreleasedVersionLabel({siteTitle, versionMetadata}) {
+  return (
+    <Translate
+      id="theme.docs.versions.unreleasedVersionLabel"
+      description="The label used to tell the user that he's browsing an unreleased doc version"
+      values={{
+        siteTitle,
+        versionLabel: <b>{versionMetadata.label}</b>,
+      }}>
+      {
+        'This is unreleased documentation for {siteTitle} {versionLabel} version.'
+      }
+    </Translate>
+  );
+}
+function UnmaintainedVersionLabel({siteTitle, versionMetadata}) {
+  return (
+    <Translate
+      id="theme.docs.versions.unmaintainedVersionLabel"
+      description="The label used to tell the user that he's browsing an unmaintained doc version"
+      values={{
+        siteTitle,
+        versionLabel: <b>{versionMetadata.label}</b>,
+      }}>
+      {
+        'This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.'
+      }
+    </Translate>
+  );
+}
+const BannerLabelComponents = {
+  unreleased: UnreleasedVersionLabel,
+  unmaintained: UnmaintainedVersionLabel,
+};
+function BannerLabel(props) {
+  const BannerLabelComponent =
+    BannerLabelComponents[props.versionMetadata.banner];
+  return <BannerLabelComponent {...props} />;
+}
+function LatestVersionSuggestionLabel({versionLabel, to, onClick}) {
+  return (
+    <Translate
+      id="theme.docs.versions.latestVersionSuggestionLabel"
+      description="The label used to tell the user to check the latest version"
+      values={{
+        versionLabel,
+        latestVersionLink: (
+          <b>
+            <Link to={to} onClick={onClick}>
+              <Translate
+                id="theme.docs.versions.latestVersionLinkLabel"
+                description="The label used for the latest version suggestion link label">
+                latest version
+              </Translate>
+            </Link>
+          </b>
+        ),
+      }}>
+      {
+        'For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).'
+      }
+    </Translate>
+  );
+}
+function DocVersionBannerEnabled({className, versionMetadata}) {
+  const {
+    siteConfig: {title: siteTitle},
+  } = useDocusaurusContext();
+  const {pluginId} = useActivePlugin({failfast: true});
+  const getVersionMainDoc = (version) =>
+    version.docs.find((doc) => doc.id === version.mainDocId);
+  const {savePreferredVersionName} = useDocsPreferredVersion(pluginId);
+  const {latestDocSuggestion, latestVersionSuggestion} =
+    useDocVersionSuggestions(pluginId);
+  // Always link to a stable landing page (Getting Started) in the latest
+  // version, falling back to the same-doc suggestion and then the main doc.
+  // This prevents 404s when an old-version page is absent in the latest version.
+  const latestVersionSuggestedDoc =
+    latestVersionSuggestion.docs.find(
+      (doc) => doc.id === LATEST_LANDING_DOC_ID,
+    ) ??
+    latestDocSuggestion ??
+    getVersionMainDoc(latestVersionSuggestion);
+  return (
+    <div
+      className={clsx(
+        className,
+        ThemeClassNames.docs.docVersionBanner,
+        'alert alert--warning margin-bottom--md',
+      )}
+      role="alert">
+      <div>
+        <BannerLabel siteTitle={siteTitle} versionMetadata={versionMetadata} />
+      </div>
+      <div className="margin-top--md">
+        <LatestVersionSuggestionLabel
+          versionLabel={latestVersionSuggestion.label}
+          to={latestVersionSuggestedDoc.path}
+          onClick={() => savePreferredVersionName(latestVersionSuggestion.name)}
+        />
+      </div>
+    </div>
+  );
+}
+export default function DocVersionBanner({className}) {
+  const versionMetadata = useDocsVersion();
+  if (versionMetadata.banner) {
+    return (
+      <DocVersionBannerEnabled
+        className={className}
+        versionMetadata={versionMetadata}
+      />
+    );
+  }
+  return null;
+}


### PR DESCRIPTION
Documentation changes (verified with `docusaurus build` + rendered previews). Rebased on `main` after PR #127 merged.

## 1. Installation polish
- **Deployment table border fix** — highlighted column no longer bleeds past the rounded corner.
- **FAQ moved** in the left sidebar to just before Release Notes.

## 2. Release notes & roadmap
- Releases **grouped by month** (newest first): **June 2026 (v3.1.0 – v3.2.0)** and **May 2026 (v3.0.x)**.
- **v3.2.0 dated 30 June 2026.** Right-column TOC limited to the month clusters.
- **Product Roadmap** moved to its own subpage; **Whisper AI Assistant tagged BETA** (and the `available` status badge fixed).

## 3. Config fix + Jira tickets
- **Deprecation fix:** `onBrokenMarkdownLinks` moved into `markdown.hooks` (Docusaurus v4 migration) — removes the warning.
- **MCRDP4S3-632** — SaaS **System Requirements** section: supported-browser minimum versions + client-side requirements as self-contained, extractable, version-stamped tables (SaaS-scoped).
- **MCRDP4S3-774** — (1) Privacy Policy link → `https://mia-care.io/privacy-policy`; (2) old-version banner always links to the current **Getting Started** page (swizzled `DocVersionBanner`) so it never 404s; (3) handbook paths use `-` instead of `_` (`getting-started`, `version-management`, `ai-configuration`) with 301 redirects from the old URLs.

https://claude.ai/code/session_01KKb5HTam8WJs3ycUqY7QxL