### PR TITLE
docs: clarify Whisper AI Assistant is available on request

### DIFF
--- a/docs/p4samd/handbook/whisper.md
+++ b/docs/p4samd/handbook/whisper.md
@@ -4,10 +4,10 @@ title: Whisper AI Assistant
 sidebar_label: Whisper AI Assistant
 ---
 
-**Whisper** is the in-platform AI assistant. It helps you keep a project compliant by continuously surfacing **compliance suggestions** for the active version and by answering questions and proposing changes through an interactive **chat**. Whisper is available from **v3.2**.
+**Whisper** is the in-platform AI assistant. It helps you keep a project compliant by continuously surfacing **compliance suggestions** for the active version and by answering questions and proposing changes through an interactive **chat**.
 
-:::info
-Whisper only appears when an administrator has enabled **AI features** for your organization and configured a chat provider. See [AI Configuration](./ai_configuration.md) to set this up.
+:::info Availability — on request
+Whisper is available from **v3.2**, but it is **not enabled by default**. Access is granted **on request**: contact Mia-Care (or your account manager) to enable Whisper for your organization. Once access has been granted, an administrator must turn on **AI features** and configure a chat provider before Whisper appears — see [AI Configuration](./ai_configuration.md).
 :::
 
 ## Opening Whisper

--- a/docs/p4samd/release-notes/v3.0.mdx
+++ b/docs/p4samd/release-notes/v3.0.mdx
@@ -45,8 +45,8 @@ Administrators can enable AI features per organization and assign an LLM provide
 
 </FeatureGrid>
 
-:::note Beta
-The Whisper AI Assistant ships in **beta** in v3.2.0. It is available for use, with coverage and proactive guidance expanding in upcoming releases.
+:::note Beta · available on request
+The Whisper AI Assistant ships in **beta** in v3.2.0 and is **available on request** — it is not enabled by default. Contact Mia-Care to have it enabled for your organization. Coverage and proactive guidance will expand in upcoming releases.
 :::
 
 #### New: Whisper AI Assistant


### PR DESCRIPTION
Whisper shipped in v3.2.0 but is **not enabled by default** — access is granted **on request** from Mia-Care. This makes that explicit in the two reader-facing places:

- **Whisper AI Assistant** handbook page — the top "Availability" admonition now states access is on request (contact Mia-Care), in addition to the existing admin AI-features/provider setup step.
- **Release notes** (v3.2.0 beta note) — now reads "beta · available on request" and notes it is not enabled by default.

Verified with `docusaurus build` (no broken links).

https://claude.ai/code/session_01KKb5HTam8WJs3ycUqY7QxL