### PR TITLE
docs: document P4SaMD v3.3.0 (org info & plan overview, product history, evaluation reliability)

### DIFF
--- a/docs/p4samd/handbook/ai_configuration.md
+++ b/docs/p4samd/handbook/ai_configuration.md
@@ -40,7 +40,7 @@ Click **Save** to store the configuration. P4SaMD **validates the credentials li
 Each workload shows its current status — **Configured** or **Not configured** — along with the date it was last updated. On the Chat workload, a **Use same configuration as Evaluation** action copies the Evaluation provider settings across, so you do not have to re-enter them.
 
 :::info Credential security
-API keys are stored **encrypted at rest (AES-256-GCM)** in the database. They are never returned to the browser; the configuration form only indicates whether a key is currently stored.
+API keys are stored **encrypted at rest (AES-256-GCM)** in the database. They are never returned to the browser; the configuration form only indicates whether a key is currently stored. As of v3.3, every AI-powered evaluation workload — Requirement Quality Score, Brownfield analysis, and Whisper compliance suggestions — consistently uses your organization's own configured **Evaluation** credentials end to end for every request.
 :::
 
 ### Available chat models

--- a/docs/p4samd/handbook/brownfield/overview.mdx
+++ b/docs/p4samd/handbook/brownfield/overview.mdx
@@ -29,7 +29,7 @@ You can pause at any time by clicking **Save as Draft** in the wizard footer. Yo
 
 ## After Evaluation
 
-When evaluation completes, the Evaluation page shows an **overall compliance score** (the percentage of the target framework currently satisfied), a **gap analysis breakdown** categorized by area with a severity rating for each gap, and a **remediation plan** organized by compliance area (Requirements, Design, Risk Management, Software Implementation, Verification, Configuration). Each task is assigned a priority (Critical, High, or Low) based on its impact on your regulatory target. The plan starts as an editable draft — you can review, reassign, and reorder tasks before confirming it. Once confirmed, you track task completion per area.
+When evaluation completes, the Evaluation page shows an **overall compliance score** (the percentage of the target framework currently satisfied), a **gap analysis breakdown** categorized by area with a severity rating and a normative **reference** for each gap, and a **remediation plan** organized by compliance area (Requirements, Design, Risk Management, Software Implementation, Verification, Configuration). Each task is assigned a priority (Critical, High, or Low) based on its impact on your regulatory target. The plan starts as an editable draft — you can review, reassign, and reorder tasks before confirming it. Once confirmed, you track task completion per area.
 
 ### Evaluation Progress
 
@@ -41,6 +41,10 @@ While the evaluation is running, the Evaluation page displays real-time progress
 4. **Evaluation** — the compliance gap analysis is computed and the remediation plan is generated
 
 Progress updates appear in real time — you can leave the page and return at any time without losing your place.
+
+### If an Evaluation Fails
+
+If processing cannot complete, the Evaluation page shows an **Evaluation Failed** state instead of results. Click **Retry Evaluation** to resubmit the same uploaded materials for a fresh evaluation, without redoing the wizard.
 
 ### Evaluation Metrics
 

--- a/docs/p4samd/handbook/organizations.mdx
+++ b/docs/p4samd/handbook/organizations.mdx
@@ -18,9 +18,11 @@ You can switch between organizations at any time without logging out. Click your
 
 ## Settings and Administration
 
-Organization administrators have access to a settings area where they can configure the organization's display name, default regulatory frameworks and compliance templates, feature toggles, and connections to external tools such as git providers, CI/CD systems, or ALM platforms. These settings are scoped to the organization and do not affect other organizations on the same installation. Only users with the **Admin** role can access this area.
+Organization administrators have access to a **Settings** area, organized into three tabs. These settings are scoped to the organization and do not affect other organizations on the same installation. Only users with the **Admin** role can see or open this area.
 
-This includes enabling **AI features** for the organization and connecting your own LLM provider, which powers the [Whisper AI Assistant](./whisper.md) and AI-based compliance evaluation. See [AI Configuration](./ai_configuration.md) for the setup steps.
+- **Information** — a Tenant Overview card showing the organization's name and status, and a Subscription Plan card showing your current plan tier and how many users and projects you are using against your plan's limits.
+- **Members** — manage who belongs to the organization and at what role (shown as **Tenant Members**; see [Roles and Permissions](../security/roles_permissions.md)).
+- **AI Configuration** — enable **AI features** for the organization and connect your own LLM provider, which powers the [Whisper AI Assistant](./whisper.md) and AI-based compliance evaluation. See [AI Configuration](./ai_configuration.md) for the setup steps.
 
 ## Data Isolation
 

--- a/docs/p4samd/handbook/products.mdx
+++ b/docs/p4samd/handbook/products.mdx
@@ -22,6 +22,14 @@ Once you click **Create**, P4SaMD provisions the project and takes you directly 
 
 If you have an existing software system that you need to bring under a formal compliance process, use **Import Project** on the Products page to open the Brownfield Import wizard. The wizard guides you through six steps to describe the project, upload technical assets, and provide existing documentation. After submission, P4SaMD runs a compliance gap analysis and generates a prioritized remediation plan. See [Brownfield Import](./brownfield/overview) for the full walkthrough.
 
+## Product Information
+
+Each project has a **Product** page (open it from **Configuration → Product** in the project sidebar) showing the product's metadata and regulatory identifiers, organized into two tabs.
+
+The **Details** tab shows the product name, description, intended use, software safety classification, the **AI Smart Assistance** toggle, target market region, and regulatory frameworks, alongside system information (created/updated timestamps and who made each change). Users with the **Admin** or **QA** role can click the edit icon in the tab bar to modify these fields; other roles see a read-only view. Some changes prompt a confirmation dialog because they could affect how the product is handled going forward.
+
+The **History** tab lists every change made to the product's metadata — who made the change and when — with a filter to narrow the feed to a single field. This gives you an audit trail of the product's regulatory identity over time.
+
 ## Managing Product Members
 
 Each project has a **Product Members** page (open it from **Members** in the project sidebar) where administrators control who has access and at what role. The page shows a member table with **search** and a **role filter**, plus a stats panel summarizing the team (Active, Admin, Tech Team, and Business users).

--- a/docs/p4samd/release-notes/v3.0.mdx
+++ b/docs/p4samd/release-notes/v3.0.mdx
@@ -9,6 +9,53 @@ import { FeatureBox, FeatureGrid } from '@site/src/components/FeatureBox';
 
 Releases are grouped by the month they shipped, newest first.
 
+## July 2026 (v3.3.0 – v3.3.1)
+
+### P4SaMD v3.3.0 — 9 July 2026
+
+Version 3.3 focuses on administrative visibility and evaluation reliability: organization admins get a clearer view of tenant status and plan usage, Product Information now keeps a change history, and both Brownfield and AI-assisted evaluations recover more gracefully from interruptions.
+
+#### New: Organization Information & Plan Overview
+
+The organization **Settings** page is now organized into three tabs — **Information**, **Members**, and **AI Configuration** — all still restricted to the **Admin** role. The new **Information** tab shows a Tenant Overview card (organization name and status) and a Subscription Plan card (current plan tier, users and projects in use against your plan's limits).
+
+#### New: Product Information Change History
+
+The **Product** page (**Configuration → Product** in the project sidebar) now has two tabs: **Details** (the existing view/edit form) and **History**. The History tab lists every change made to the product's metadata — product name, description, intended use, safety classification, target market region, regulatory frameworks, and AI-powered type — showing who made the change and when, with a filter to narrow the feed to a single field.
+
+#### Improved: Brownfield Evaluation
+
+- **Retry Evaluation** is now available on a failed evaluation. Open the failed session's Evaluation page and click **Retry Evaluation** to resubmit the same materials for a fresh evaluation without redoing the wizard.
+- The gap analysis now surfaces a normative reference for more gaps, drawing on additional regulatory metadata (such as the specific article or regulation) supplied by the applicable framework.
+
+:::caution Brownfield evaluation accuracy fix
+This release fixes a defect in the Brownfield compliance check where certain gaps could be reported as compliant when they were not. If you rely on a Brownfield evaluation completed before 9 July 2026, re-run the evaluation (using the new **Retry Evaluation** button, or by starting a new session) to get corrected results.
+:::
+
+#### Improved: Evaluation Reliability
+
+Requirement quality-score, Brownfield, and Whisper evaluations now recover more predictably from interruptions:
+
+- An evaluation that stalls (for example, because of a slow or unresponsive AI provider) now fails with a clear error after a bounded wait instead of remaining in progress for hours.
+- An evaluation left in progress by a platform restart is now automatically detected and marked as failed shortly afterward, instead of appearing to run indefinitely — so you know when it is safe to retry.
+- Evaluations are no longer at risk of being incorrectly marked as failed during routine platform maintenance.
+
+#### Fixed
+
+- Resuming a Whisper chat conversation after confirming a proposed action no longer occasionally fails to send your next message.
+
+#### Security
+
+All AI-powered evaluation workloads — Requirement Quality Score, Brownfield analysis, and Whisper compliance suggestions — now consistently use your organization's own configured **Evaluation** credentials (see [AI Configuration](../handbook/ai_configuration.md)) end to end for every request.
+
+#### For developers
+
+The requirements REST API and MCP tool catalog gained new capabilities for managing requirement hierarchy programmatically: re-parenting a requirement, setting labels and an initial status at creation, dedicated endpoints for managing sections, and creating requirement-to-requirement traceability links. These are currently available via the API and MCP only; UI support is planned for a future release.
+
+### P4SaMD v3.3.1 — 9 July 2026 (patch)
+
+A same-day patch fixing a display defect: requirement level labels could show the wrong text in the requirements table. No other user-facing changes.
+
 ## June 2026 (v3.1.0 – v3.2.0)
 
 Three releases shipped in June: the **Whisper AI Assistant** and AI configuration (v3.2.0), a storage migration (v3.1.1), and the System Design lifecycle and team-administration work (v3.1.0).


### PR DESCRIPTION
## Summary

Documents the P4SaMD **v3.3.0** release (Configurations tag `v3.3.0-PROD`, 2026-07-09) and the same-day **v3.3.1** frontend patch. Previously documented version was v3.2.0.

Only three services changed for this release: `backend` v0.7.1→v0.8.0, `frontend` 0.7.1→0.8.0, `policy-engine` v0.8.1→v0.9.0.

## Changes

- **Release notes** (`release-notes/v3.0.mdx`): new "July 2026 (v3.3.0 – v3.3.1)" section, incl. a caution admonition about re-running pre-9-July Brownfield evaluations, and a "For developers" note for backend/MCP-only capabilities not yet in the UI.
- **Organizations** (`handbook/organizations.mdx`): Settings "Information" tab (tenant overview + subscription plan/usage).
- **Products** (`handbook/products.mdx`): new "Product Information" section (Details / History tabs).
- **Brownfield** (`handbook/brownfield/overview.mdx`): Retry Evaluation button, gap normative-reference enrichment.
- **AI configuration** (`handbook/ai_configuration.md`): tenant-credential-consistency note.

## Version Impact

- No new Docusaurus version created; `latest` updated in place.
- v3.3.1 captured as a release-notes patch line (frontend-only, per patch-versioning rule).

## Checklist

- [x] `yarn build` passes (Node 20.19.6) — exit 0, no broken links/anchors
- [x] No internal identifiers, ticket refs, or file/endpoint names in page content
- [x] Follows existing handbook structure and role model