### PR TITLE
docs(p4samd): v3.4.0 release notes and handbook updates

### DIFF
--- a/docs/p4samd/handbook/requirements.mdx
+++ b/docs/p4samd/handbook/requirements.mdx
@@ -24,6 +24,8 @@ Every requirement moves through four states: `Draft → In Review → Approved �
 
 If a requirement becomes obsolete, use the **Deprecate** action in the detail view. Deprecation requires a mandatory rationale, triggers an automatic change request, and marks the requirement as deprecated while retaining it in the system for traceability and audit purposes.
 
+To move a requirement to a different place in the hierarchy, use the **Change parent** action in the detail view. It opens a dedicated picker so you can search for and select the new parent without leaving the requirement you're editing.
+
 ## Traceability
 
 P4SaMD maintains bidirectional traceability automatically. In the requirement detail view you can see all **linked software items** (design elements that implement the requirement), **linked risks** (with a coverage indicator), **linked test cases** (that verify it), and a full **change history** showing every edit made, by whom, and when.

--- a/docs/p4samd/handbook/sbom.md
+++ b/docs/p4samd/handbook/sbom.md
@@ -6,85 +6,61 @@ sidebar_label: SBOM
 
 # Software Bill Of Materials (SBOM)
 
-When developing Software as a Medical Device (SaMD), the Software Bill of Materials (SBOM) is a crucial tool for enhancing transparency, security, and compliance. A SBOM is an inventory of all the software components, libraries, and dependencies that make up a particular software item and includes information like versioning, licensing and known vulnerabilities. Much like a bill of materials in hardware manufacturing, it provides a detailed mapping of what constitutes the software.
+When developing Software as a Medical Device (SaMD), the Software Bill of Materials (SBOM) is a crucial tool for enhancing transparency, security, and compliance. An SBOM is an inventory of all the software components, libraries, and dependencies that make up a particular software item, including versioning, licensing, and known vulnerabilities. Much like a bill of materials in hardware manufacturing, it provides a detailed mapping of what constitutes the software.
 
-Medical device software must adhere to strict regulatory standards, such as those outlined by the FDA, EU MDR, ISO 13485 and ISO 62304. A SBOM helps ensuring that all components are accounted for, facilitating traceability and reducing the risk of security vulnerabilities that could arise from third-party software. Knowing exactly what components are used and their relationships allows developers to easily assess potential risks and vulnerabilities and promptly identify and remediate any issue in third-party libraries or proprietary components. This is particularly important in ensuring the security and safety of medical devices, where vulnerabilities in software can directly impact patient health.
+Medical device software must adhere to strict regulatory standards, such as those outlined by the FDA, EU MDR, ISO 13485, and IEC 62304. An SBOM helps ensure that all components are accounted for, facilitating traceability and reducing the risk of security vulnerabilities that could arise from third-party software.
 
-Furthermore, the SBOM is vital for maintaining ongoing compliance during the entity software lifecycle. As software updates and patches are rolled out, a SBOM ensures that developers and regulators can track changes in the software’s composition, offering a transparent view of the evolving system and ensuring that changes do not introduce new risks.
+P4SaMD generates SBOMs for you natively — you no longer need to run a separate scanning tool in your own CI/CD pipeline and push the result in. Open the **SBOM** tab on a software item's detail page, or on the **System Design** page for a project-wide view, to get started.
 
-In summary, the SBOM is a fundamental component of SaMD development. It serves as a safeguard for both patient safety and product integrity by offering visibility into the software’s structure, making it easier to manage risks, maintain compliance, and ensure the overall quality of the medical device.
+## How SBOMs are generated
 
-## How to download the SBOM
+For a software item whose **repository link** points to a resolvable git reference (branch, tag, or commit), P4SaMD can generate its SBOM automatically: it clones the linked repository at the resolved reference and scans it server-side to produce a standard [CycloneDX][cyclone-dx] document. No credentials or tooling are required on your side — the whole process runs inside P4SaMD.
 
-P4SaMD can automatically generate the aggregated SBOM of all the custom services included in the system design of a system version.
+For software items that aren't backed by a resolvable git reference (for example, third-party or SOUP components without a linked repository), automatic generation isn't available. In this case the SBOM tab shows a banner explaining why, and you can [import a CycloneDX file manually](#importing-an-sbom) instead.
 
-As a user, you can download the SBOM from the *Software Items* section by clicking on the `Download complete SBOM` button.
+### Triggering a scan
 
-## What's in the SBOM
+A scan can start in three ways:
 
-The generated SBOM, currently available as Excel file, provides an inventory of all software items dependencies and contains the following sections:
+- **Manually**: click **Generate SBOM** (or **Re-scan** if one already exists) on the SBOM tab.
+- **Automatically on change**: linking a new repository to a software item, or changing which version/ref it points to, triggers a fresh scan.
+- **On a schedule**: configure a **daily** or **weekly** automatic scan for a software item from the SBOM tab. The schedule targets the item's active version and shows badges for when it last ran and when it's next due.
 
-- `Info`: document generation metadata, including when it was generated (in `dd/mm/yyyy` format) and who generated it (user name and email address);
-- `SBOM Report`: the list software items dependencies, with the following information:
-  - software item name and version
-  - library name and version
-  - licensing information
-- `Missing SBOMs` (optional): a list of software items (name and version) for which a SBOM was not available at time of generation.
+While a scan is running, the tab shows a **generating** status. If a scan doesn't report back within the expected window (for example after an interruption), P4SaMD automatically detects and recovers it, so a stuck scan does not block you indefinitely — you can simply re-scan.
 
-## How to generate a SBOM
+## Browsing an SBOM
 
-P4SaMD is designed to automatically collect the SBOM of each custom service through a webhook and currently supports the [CycloneDX][cyclone-dx] format.
+Once a scan completes, the SBOM tab shows the **status** (not generated / generating / ready) and lets you:
 
-You can easily generate the SBOM inside a CI/CD pipeline with tools like [syft][syft]:
+- **Download** the raw generated document.
+- Browse the full **component table** for the software item, with filtering.
+- Use the **version selector** to switch between SBOMs generated for different versions or refs of the same software item, so you can compare what a component's dependency footprint looked like at an earlier point.
+- Open a **diff** between two scans of the same version to see which components were added, removed, or changed.
 
-```shell
-syft "/path/to/your/source/code" -o cyclonedx-json=gl-sbom-report.cdx.json
-```
+For each component you can review its identity (name, version) and set a per-version **status** and **notes** — for example to record that a flagged component has been reviewed and accepted, or to leave context for the next reviewer. This status is scoped to the P4SaMD version you're working in, so the same component can be tracked independently across different releases of your product.
 
-To submit the generated SBOM file to P4SaMD you send an HTTP request to the P4SaMD `POST /webhook/sboms/` endpoint:
+## Project-wide view
 
-```shell
-curl -X POST \
-  ${P4SAMD_BACKEND_URL}/webhook/sboms/${CI_PROJECT_ID}/${CI_COMMIT_TAG} \
-  -H "secret:${P4SAMD_API_KEY}" \
-  -H "Content-Type:application/json" \
-  --data-binary "@${P4SAMD_SBOM_FILE}"
-```
+The **System Design** page's SBOM tab gives you a project-level view across every software item's system design in the current version:
 
-where:
+- An aggregated **component table** across all software items, with filtering.
+- A project-wide **export** of the combined SBOM.
+- A project-wide **diff** between two scans.
 
-- `P4SAMD_BACKEND_URL` is the base URL of your P4SaMD backend service;
-- `CI_PROJECT_ID` is the ID of the repository associated to the software item;
-- `CI_COMMIT_TAG` is the name of the tag representing the version of the software item (we recommend following [semantic versioning][semantic-versioning]);
-- `P4SAMD_API_KEY` is the API key required to authenticate with P4SaMD;
-- `P4SAMD_SBOM_FILE`: absolute or relative path to the SBOM file created previously with [syft][syft] or similar tools.
+This is the fastest way to answer "what changed across the whole product between these two releases" without opening every software item individually.
 
-Using the webhook you can easily integrate P4SaMD in your existing DevOps infrastructure and collect all the relevant SBOMs, ensuring they are always up-to-date in P4SaMD.
+## Importing an SBOM
 
-### Troubleshooting
+If a software item can't be scanned automatically (no resolvable git reference), you can import an existing CycloneDX file for it instead. Use the **preview** step before confirming the import to check what will be recorded — nothing is saved until you confirm.
 
-If the CI/CD pipeline fails, when you download the complete SBOM report some information may be missing or outdated, since the SBOM of one or more software items could be missing or outdated.
+## Exporting
 
-If P4SaMD never collected the SBOM of a software item included in the system design, its name and version will be reported in the SBOM report under the `Missing SBOMs` section, so the developers are aware of the issue.
+You can export an SBOM — for a single software item's scan or as a project-wide aggregate — in standard CycloneDX format at any time, for use in your own compliance records or for sharing with auditors and customers.
 
-If P4SaMD collected the SBOM for a software item version, which was later changed but not correctly processed by P4SaMD, the complete SBOM report may contain outdated information.
-This issue could arise during the development phase of the software lifecycle, when the software dependencies may be updated, but should not affect stable versions.
+## Troubleshooting
 
-To further mitigate these risks you can adopt additional measures, like:
-
-- design your CI/CD pipeline to fail as soon as the BOM generation or submission encounter some errors and prevent the build and release of the software version;
-
-- add a step in your CI/CD pipeline to be executed when the pipeline fails and send some automatic alerts:
- 
- ```yaml
- notify_failure:
-  stage: notify
-  script:
-    - 'if [ "$CI_PIPELINE_STATUS" == "failed" ]; then ... fi'
-  when: on_failure
- ```
-
+- If a software item's SBOM tab shows **not generated**, check that it has a repository linked and that the linked reference (branch/tag/commit) can be resolved. If it can't (for example, a component with no linked repository), use [manual import](#importing-an-sbom) instead.
+- If a scan appears stuck in **generating** for an unusually long time, P4SaMD's automatic recovery will eventually mark it as failed so you can re-scan; you don't need to take any action other than retrying.
+- Component **status/notes** are per-version — if you don't see a note you expect, check that you're looking at the same P4SaMD version it was recorded against.
 
 [cyclone-dx]: https://cyclonedx.org/
-[syft]: https://github.com/anchore/syft
-[semantic-versioning]: https://semver.org

--- a/docs/p4samd/release-notes/v3.0.mdx
+++ b/docs/p4samd/release-notes/v3.0.mdx
@@ -9,6 +9,68 @@ import { FeatureBox, FeatureGrid } from '@site/src/components/FeatureBox';
 
 Releases are grouped by the month they shipped, newest first.
 
+## August 2026 (v3.4.0)
+
+### P4SaMD v3.4.0 — 6 August 2026
+
+Version 3.4 introduces native **Software Bill of Materials (SBOM)** generation and a new **approval workflow for uploaded unit test reports**, alongside smaller improvements to the Requirements and System Overview pages.
+
+<FeatureGrid>
+
+<FeatureBox icon="📦" title="Native SBOM Generation">
+
+P4SaMD now generates a CycloneDX Software Bill of Materials for you directly — no separate scanning tool or CI/CD integration required. Trigger a scan manually, automatically on a repository/version change, or on a daily/weekly schedule, then browse components, compare versions, and export.
+
+</FeatureBox>
+
+<FeatureBox icon="✅" title="Run Approval & Guided Traceability Review">
+
+Uploaded unit test reports now go through a dedicated approval lifecycle — Incomplete → Traceability Required → Ready for Approval → Pending Third-Party Approval → Approved — with a submit-for-approval flow to a designated reviewer and an opt-in guided review that walks you through linking test results to software items first.
+
+</FeatureBox>
+
+</FeatureGrid>
+
+#### New: Native SBOM Generation
+
+Every software item with a resolvable repository link now has an **SBOM** tab that generates and stores its Software Bill of Materials automatically — see the [SBOM](../handbook/sbom.md) handbook page for the full walkthrough. Highlights:
+
+- Automatic generation triggered manually, on a repository/version change, or on a configurable daily/weekly schedule.
+- A version selector to browse SBOMs across different versions or refs of the same software item, plus a diff view between any two scans.
+- A project-wide SBOM view on the **System Design** page, aggregating components across all software items with its own diff and export.
+- Manual import (with a preview step) for software items that aren't backed by a resolvable git reference.
+- Per-version component **status** and **notes**, so you can record that a component has been reviewed and why.
+
+#### New: Run Approval & Guided Traceability Review for Unit Test Reports
+
+Uploaded unit test reports now have a dedicated **Run Approval** view covering their full approval lifecycle. Submitting a report for approval routes it to a designated project reviewer; if the run contains failing test cases, a rationale is required before it can be submitted. Reports also surface non-blocking traceability gaps — test cases not yet linked to a software item or requirement — and an opt-in **guided traceability review** setting walks you through resolving those links before approval.
+
+#### Improved
+
+- The **Product Progression Score** card has been redesigned with a fuller breakdown and clearer messaging for items that are tracked but not yet progressed.
+- The Requirement Detail page layout has been overhauled, including a redesigned text editor for requirement content.
+- Requirements gained a **Change parent** action with a dedicated picker — see [Requirements](../handbook/requirements.mdx#requirement-lifecycle).
+- The verification table's **Last Result** column now shows a hover popover with test result details.
+
+#### Fixed
+
+- The software item name displayed incorrectly in the System Design tree in some cases.
+- The Product Progression Score calculation and display have been corrected.
+- Unlimited plans now surface correctly in the member-invite flow, and the invite flow's plan-limit messaging has been clarified.
+- Requirement and Risk history tab entries are now ordered correctly.
+- The unit test report list's name filter now matches the uploaded file name instead of an optional label.
+- Seat-limit enforcement is now consistent with the limits shown on the tenant **Information** tab.
+
+#### Security
+
+You'll now receive an email notification when a failed login attempt is detected on your account, including the date/time and originating IP address, so you can spot unauthorized access attempts sooner.
+
+#### For developers
+
+- Fixed an MCP defect where creating a software item or SOUP entity via the MCP tool catalog always failed, and corrected an error message that referenced the wrong domain for software-item hierarchy violations.
+- Requirement↔requirement traceability MCP tools now propagate a real request ID on error responses, for easier correlation when debugging.
+- Evaluation stall detection (introduced in v3.3.0) now allows a longer window before failing a stalled job, reducing false positives on legitimately slow evaluations.
+
 ## July 2026 (v3.3.0 – v3.3.1)
 
 ### P4SaMD v3.3.0 — 9 July 2026

--- a/sidebars.json
+++ b/sidebars.json
@@ -71,6 +71,11 @@
           "type": "doc"
         },
         {
+          "id": "p4samd/handbook/sbom",
+          "label": "SBOM",
+          "type": "doc"
+        },
+        {
           "label": "Brownfield Import",
           "type": "category",
           "items": [


### PR DESCRIPTION
## What

Documents the **P4SaMD v3.4.0** release (6 August 2026) in the handbook.

### Release note
Adds a new **August 2026 (v3.4.0)** section to `docs/p4samd/release-notes/v3.0.mdx` (above July 2026), following the existing month-grouped style. Covers:
- **Native SBOM generation** (flagship) — server-side CycloneDX scans per software item, scheduling, version diff, project-wide view, manual import, export
- **Run Approval & guided traceability review** for uploaded unit test reports (new approval lifecycle)
- **Improved** — Product Progression Score redesign, Requirement Detail overhaul, Change parent action, verification Last Result popover
- **Fixed** — System Design tree name, progression score, invite-flow plan display, history ordering, unit-test-report name filter, seat-limit alignment
- **Security** — failed-login email notification (date/time + IP)
- **For developers** — MCP `create_software_item`/SOUP fix, traceability request-id propagation, evaluation stall-timeout tuning

### Handbook
- `handbook/sbom.md` — rewritten to the shipped native server-side SBOM flow (replaces the obsolete CI/webhook-based description)
- `handbook/requirements.mdx` — documents the new **Change parent** action
- `sidebars.json` — surfaces the SBOM page in the Handbook sidebar (was an orphaned file)

## Evidence
Derived from the `Configurations` `v3.3.1-PROD → v3.4.0-PROD` release-pin diff (backend v0.9.0, frontend v0.9.0, new `sbom-creator-svc`, `SBOM_*`/`EVALUATION_STALL_TIMEOUT` env) and the backend/frontend `[0.9.0]` CHANGELOG sections + `sbom-creator-svc` README.

## Verification
`npx docusaurus build` succeeds with no broken links.

## Notes for reviewers
- Only the current docs (`docs/p4samd/...`) were edited — no `versioned_docs` snapshots.
- **No** dedicated Run Approval / Unit Test Reports handbook page was added — the existing `verification.md` describes an older ALM-integration model and isn't in the live sidebar, so this feature is currently release-note-only. Flag if you want it promoted to a first-class page.
- `ai_configuration.md` / `whisper.md` left untouched (no v0.9.0 changes in those areas).